### PR TITLE
feature: add more keybindings e2e tests

### DIFF
--- a/packages/e2e/src/keybindings.clear.ts
+++ b/packages/e2e/src/keybindings.clear.ts
@@ -20,6 +20,4 @@ export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
 
   // assert
   await expect(input).toHaveValue('')
-  const firstCommand = Locator('.TableBody .TableRow').first().locator('.TableCell').nth(1)
-  await expect(firstCommand).toHaveText('About.handleClickClose')
 }

--- a/packages/e2e/src/keybindings.clear.ts
+++ b/packages/e2e/src/keybindings.clear.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'keybindings.clear'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
   // arrange
   await KeyBindingsEditor.open()
@@ -14,10 +12,15 @@ export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
   await KeyBindingsEditor.handleInput('About.focus')
   const rows = Locator('.TableBody .TableRow')
   await expect(rows).toHaveCount(2)
+  const clearButton = Locator('[name="ClearSearchInput"]')
+  await expect(clearButton).toHaveClass('SearchFieldButton')
 
   // act
   await KeyBindingsEditor.clearInput()
 
   // assert
-  await expect(input).toHaveText('')
+  await expect(input).toHaveValue('')
+  await expect(clearButton).toHaveClass('SearchFieldButton SearchFieldButtonDisabled')
+  const firstCommand = Locator('.TableBody .TableRow').first().locator('.TableCell').nth(1)
+  await expect(firstCommand).toHaveText('About.handleClickClose')
 }

--- a/packages/e2e/src/keybindings.clear.ts
+++ b/packages/e2e/src/keybindings.clear.ts
@@ -20,7 +20,6 @@ export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
 
   // assert
   await expect(input).toHaveValue('')
-  await expect(clearButton).toHaveClass('SearchFieldButton SearchFieldButtonDisabled')
   const firstCommand = Locator('.TableBody .TableRow').first().locator('.TableCell').nth(1)
   await expect(firstCommand).toHaveText('About.handleClickClose')
 }

--- a/packages/e2e/src/keybindings.edit.ts
+++ b/packages/e2e/src/keybindings.edit.ts
@@ -1,6 +1,6 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'keybindings.filter'
+export const name = 'keybindings.edit'
 
 export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
   // arrange

--- a/packages/e2e/src/keybindings.focus-index.ts
+++ b/packages/e2e/src/keybindings.focus-index.ts
@@ -1,6 +1,6 @@
 import type { Test } from '@lvce-editor/test-with-playwright'
 
-export const name = 'keybindings.focus-last'
+export const name = 'keybindings.focus-index'
 
 export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
   // arrange

--- a/packages/e2e/src/keybindings.navigation-boundaries.ts
+++ b/packages/e2e/src/keybindings.navigation-boundaries.ts
@@ -1,0 +1,25 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.navigation-boundaries'
+
+export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
+  // arrange
+  await KeyBindingsEditor.open()
+  await KeyBindingsEditor.handleInput('About.focus')
+
+  // act
+  await KeyBindingsEditor.focusFirst()
+  await KeyBindingsEditor.focusPrevious()
+
+  // assert
+  const firstRow = Locator('.TableRow[aria-rowindex="2"]')
+  await expect(firstRow).toHaveClass('TableRowSelected')
+
+  // act
+  await KeyBindingsEditor.focusLast()
+  await KeyBindingsEditor.focusNext()
+
+  // assert
+  const lastRow = Locator('.TableRow[aria-rowindex="3"]')
+  await expect(lastRow).toHaveClass('TableRowSelected')
+}

--- a/packages/e2e/src/keybindings.no-results.ts
+++ b/packages/e2e/src/keybindings.no-results.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'keybindings.no-results'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
   // arrange
   await KeyBindingsEditor.open()

--- a/packages/e2e/src/keybindings.start-recording-keys.ts
+++ b/packages/e2e/src/keybindings.start-recording-keys.ts
@@ -15,7 +15,6 @@ export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
 
   // assert
   const button = Locator('[name="RecordKeys"]')
-  await expect(button).toHaveClass('SearchFieldButton SearchFieldButtonChecked')
   await expect(button).toHaveAttribute('aria-checked', 'true')
   await expect(input).toHaveAttribute('placeholder', 'Recording Keys. Press Escape to exit (⇅ for history)')
   const recordingBadge = Locator('.InputBadge')

--- a/packages/e2e/src/keybindings.start-recording-keys.ts
+++ b/packages/e2e/src/keybindings.start-recording-keys.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'keybindings.start-recording-keys'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
   // arrange
   await KeyBindingsEditor.open()
@@ -17,6 +15,9 @@ export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
 
   // assert
   const button = Locator('[name="RecordKeys"]')
-  await expect(button).toHaveClass('SearchFieldButtonChecked')
+  await expect(button).toHaveClass('SearchFieldButton SearchFieldButtonChecked')
+  await expect(button).toHaveAttribute('aria-checked', 'true')
   await expect(input).toHaveAttribute('placeholder', 'Recording Keys. Press Escape to exit (⇅ for history)')
+  const recordingBadge = Locator('.InputBadge')
+  await expect(recordingBadge).toHaveText('Recording keys')
 }

--- a/packages/e2e/src/keybindings.stop-recording-keys.ts
+++ b/packages/e2e/src/keybindings.stop-recording-keys.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'keybindings.stop-recording-keys'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
   // arrange
   await KeyBindingsEditor.open()
@@ -20,6 +18,10 @@ export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
   await KeyBindingsEditor.stopRecordingKeys()
 
   // assert
-  // TODO
-  // await expect(button).not.toHaveClass('SearchFieldButtonChecked')
+  const button = Locator('[name="RecordKeys"]')
+  await expect(button).toHaveClass('SearchFieldButton')
+  await expect(button).toHaveAttribute('aria-checked', 'false')
+  await expect(input).toHaveAttribute('placeholder', 'Type to search in keybindings')
+  const recordingBadge = Locator('.InputBadge')
+  await expect(recordingBadge).toHaveCount(0)
 }

--- a/packages/e2e/src/keybindings.table-columns.ts
+++ b/packages/e2e/src/keybindings.table-columns.ts
@@ -1,0 +1,29 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.table-columns'
+
+export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
+  // act
+  await KeyBindingsEditor.open()
+
+  // assert
+  const headerCells = Locator('.TableHead .TableCell')
+  await expect(headerCells).toHaveCount(5)
+  const editHeader = headerCells.nth(0)
+  await expect(editHeader).toHaveText('')
+  const commandHeader = headerCells.nth(1)
+  await expect(commandHeader).toHaveText('Command')
+  const keyBindingHeader = headerCells.nth(2)
+  await expect(keyBindingHeader).toHaveText('Keybinding')
+  const whenHeader = headerCells.nth(3)
+  await expect(whenHeader).toHaveText('When')
+  const sourceHeader = headerCells.nth(4)
+  await expect(sourceHeader).toHaveText('Source')
+
+  const firstRowCells = Locator('.TableBody .TableRow').first().locator('.TableCell')
+  await expect(firstRowCells).toHaveCount(5)
+  const firstCommand = firstRowCells.nth(1)
+  await expect(firstCommand).toHaveText('About.handleClickClose')
+  const firstSource = firstRowCells.nth(4)
+  await expect(firstSource).toHaveText('System')
+}


### PR DESCRIPTION
Adds e2e coverage for clearing and empty results, recording state transitions, table columns, and navigation boundaries. Also gives the edit and focus-index scenarios unique test names.