### PR TITLE
feature: enable recommended virtual dom lint rules

### DIFF
--- a/eslint.config.js
+++ b/eslint.config.js
@@ -2,6 +2,7 @@ import * as config from '@lvce-editor/eslint-config'
 
 export default [
   ...config.default,
+  ...config.recommendedVirtualDom,
   {
     ignores: ['packages/keybindings-view/src/keyBindingsViewWorkerMain.ts'],
   },
@@ -14,6 +15,20 @@ export default [
       '@cspell/spellchecker': 'off',
       'sonarjs/arguments-order': 'off',
       'sonarjs/max-switch-cases': 'off',
+    },
+  },
+  {
+    files: ['packages/keybindings-view/src/parts/GetKeyBindingsHeaderVirtualDom/GetKeyBindingsHeaderVirtualDom.ts'],
+    rules: {
+      'virtual-dom/prefer-constants': 'off',
+    },
+  },
+  {
+    files: ['packages/keybindings-view/test/**/*.ts'],
+    rules: {
+      'virtual-dom/prefer-constants': 'off',
+      'virtual-dom/prefer-merge-class-names': 'off',
+      'virtual-dom/prefer-state-destructuring': 'off',
     },
   },
 ]

--- a/packages/keybindings-view/src/parts/GetKeyBindingsTableVirtualDom/GetKeyBindingsTableVirtualDom.ts
+++ b/packages/keybindings-view/src/parts/GetKeyBindingsTableVirtualDom/GetKeyBindingsTableVirtualDom.ts
@@ -7,6 +7,7 @@ import * as GetKeyBindingsTableBodyVirtualDom from '../GetKeyBindingsTableBodyVi
 import * as GetKeyBindingsTableColGroupVirtualDom from '../GetKeyBindingsTableColGroupVirtualDom/GetKeyBindingsTableColGroupVirtualDom.ts'
 import * as GetKeyBindingsTableHeadVirtualDom from '../GetKeyBindingsTableHeadVirtualDom/GetKeyBindingsTableHeadVirtualDom.ts'
 import * as KeyBindingsStrings from '../KeyBindingStrings/KeyBindingStrings.ts'
+import * as TabIndex from '../TabIndex/TabIndex.ts'
 
 export const getTableDom = (
   filteredItemsCount: number,
@@ -22,7 +23,7 @@ export const getTableDom = (
       childCount: 3,
       className: ClassNames.Table,
       onFocus: DomEventListenerFunctions.HandleTableFocus,
-      tabIndex: 0,
+      tabIndex: TabIndex.Focusable,
       type: VirtualDomElements.Table,
     },
     ...GetKeyBindingsTableColGroupVirtualDom.getKeyBindingsTableColGroupVirtualDom(columnWidth1, columnWidth2, columnWidth3),

--- a/packages/keybindings-view/src/parts/HandleScrollBarPointerMove/HandleScrollBarPointerMove.ts
+++ b/packages/keybindings-view/src/parts/HandleScrollBarPointerMove/HandleScrollBarPointerMove.ts
@@ -3,13 +3,13 @@ import { getNewDeltaPercent } from '../ScrollBarFunctions/ScrollBarFunctions.ts'
 import { setDeltaY } from '../SetDeltaY/SetDeltaY.ts'
 
 export const handleScrollBarPointerMove = (state: KeyBindingsState, clientY: number): KeyBindingsState => {
-  const { finalDeltaY, height, scrollBarHeight, scrollBarPointerDown } = state
+  const { finalDeltaY, height, scrollBarHeight, scrollBarPointerDown, y } = state
 
   if (!scrollBarPointerDown || !scrollBarHeight) {
     return state
   }
 
-  const relativeY = clientY - state.y
+  const relativeY = clientY - y
   const { percent } = getNewDeltaPercent(height, scrollBarHeight, relativeY)
   const newDeltaY = percent * finalDeltaY
 

--- a/packages/keybindings-view/src/parts/HandleWheel/HandleWheel.ts
+++ b/packages/keybindings-view/src/parts/HandleWheel/HandleWheel.ts
@@ -2,5 +2,6 @@ import type { KeyBindingsState } from '../KeyBindingsState/KeyBindingsState.ts'
 import * as SetDeltaY from '../SetDeltaY/SetDeltaY.ts'
 
 export const handleWheel = (state: KeyBindingsState, deltaMode: number, deltaY: number): KeyBindingsState => {
-  return SetDeltaY.setDeltaY(state, state.deltaY + deltaY)
+  const { deltaY: currentDeltaY } = state
+  return SetDeltaY.setDeltaY(state, currentDeltaY + deltaY)
 }

--- a/packages/keybindings-view/src/parts/LoadContent/LoadContent.ts
+++ b/packages/keybindings-view/src/parts/LoadContent/LoadContent.ts
@@ -10,8 +10,18 @@ import * as RestoreState from '../RestoreState/RestoreState.ts'
 import * as ScrollBarFunctions from '../ScrollBarFunctions/ScrollBarFunctions.ts'
 
 export const loadContent = async (state: KeyBindingsState, savedState: unknown): Promise<KeyBindingsState> => {
-  const { contentPadding, editingWhenExpression, height, itemHeight, minimumSliderSize, paddingLeft, searchHeaderHeight, tableHeaderHeight, width } =
-    state
+  const {
+    contentPadding,
+    editingWhenExpression,
+    height,
+    itemHeight,
+    minimumSliderSize,
+    paddingLeft,
+    searchHeaderHeight,
+    selectedIndex: currentSelectedIndex,
+    tableHeaderHeight,
+    width,
+  } = state
   Assert.number(width)
   const parsedKeyBindings = await loadKeyBindings()
   const maxVisibleItems = GetMaxVisibleItems.getMaxVisibleItems(height, searchHeaderHeight, tableHeaderHeight, itemHeight)
@@ -51,7 +61,7 @@ export const loadContent = async (state: KeyBindingsState, savedState: unknown):
     resizerOneLeft,
     resizerTwoLeft,
     scrollBarHeight,
-    selectedIndex: typeof selectedIndex === 'number' ? selectedIndex : state.selectedIndex,
+    selectedIndex: typeof selectedIndex === 'number' ? selectedIndex : currentSelectedIndex,
     value: savedValue,
     visibleItems,
   }

--- a/packages/keybindings-view/src/parts/TabIndex/TabIndex.ts
+++ b/packages/keybindings-view/src/parts/TabIndex/TabIndex.ts
@@ -1,0 +1,1 @@
+export const Focusable = 0


### PR DESCRIPTION
## Summary
- enable the recommended virtual DOM ESLint configuration
- replace raw tab index and direct state reads in production paths
- scope fixture and unavailable shared ARIA constant exceptions narrowly

## Validation
- npm run lint
- npm run build
- npm run type-check
- npm test (278 passed, 16 pre-existing skips)
- npm run measure