### PR TITLE
fix: copy keybinding command titles

### DIFF
--- a/packages/e2e/src/keybindings.copy-command-id.ts
+++ b/packages/e2e/src/keybindings.copy-command-id.ts
@@ -6,12 +6,12 @@ export const test: Test = async ({ ClipBoard, KeyBindingsEditor }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()
   await KeyBindingsEditor.open()
-  await KeyBindingsEditor.handleInput('About.focus')
+  await KeyBindingsEditor.handleInput('ActivityBar.focusNext')
   await KeyBindingsEditor.focusFirst()
 
   // act
   await KeyBindingsEditor.copyCommandId()
 
   // assert
-  await ClipBoard.shouldHaveText('About.focusNext')
+  await ClipBoard.shouldHaveText('ActivityBar.focusNext')
 }

--- a/packages/e2e/src/keybindings.copy-command-title.ts
+++ b/packages/e2e/src/keybindings.copy-command-title.ts
@@ -6,12 +6,12 @@ export const test: Test = async ({ ClipBoard, KeyBindingsEditor }) => {
   // arrange
   await ClipBoard.enableMemoryClipBoard()
   await KeyBindingsEditor.open()
-  await KeyBindingsEditor.handleInput('About.focus')
+  await KeyBindingsEditor.handleInput('ActivityBar.focusNext')
   await KeyBindingsEditor.focusFirst()
 
   // act
   await KeyBindingsEditor.copyCommandTitle()
 
   // assert
-  await ClipBoard.shouldHaveText('About.focusNext')
+  await ClipBoard.shouldHaveText('ActivityBar: Focus Next')
 }

--- a/packages/keybindings-view/src/parts/CopyCommandTitle/CopyCommandTitle.ts
+++ b/packages/keybindings-view/src/parts/CopyCommandTitle/CopyCommandTitle.ts
@@ -8,6 +8,9 @@ export const copyCommandTitle = async (state: KeyBindingsState): Promise<KeyBind
     return state
   }
   const { command } = item
-  await RendererWorker.writeClipBoardText(command)
+  const entries: readonly { readonly id: string; readonly label: string }[] = await RendererWorker.invoke('Layout.getAllQuickPickMenuEntries')
+  const entry = entries.find((entry) => entry.id === command)
+  const title = entry?.label || command
+  await RendererWorker.writeClipBoardText(title)
   return state
 }

--- a/packages/keybindings-view/test/CopyCommandId.test.ts
+++ b/packages/keybindings-view/test/CopyCommandId.test.ts
@@ -33,7 +33,7 @@ test('copyCommandId - writes focused command to clipboard', async () => {
 })
 
 test('copyCommandId - no focused item does nothing', async () => {
-  RendererWorker.registerMockRpc({
+  using mockRpc = RendererWorker.registerMockRpc({
     'ClipBoard.writeText'() {
       throw new Error('should not be called')
     },
@@ -47,5 +47,6 @@ test('copyCommandId - no focused item does nothing', async () => {
 
   const result: KeyBindingsState = await CopyCommandId.copyCommandId(state)
 
+  expect(mockRpc.invocations).toEqual([])
   expect(result).toBe(state)
 })

--- a/packages/keybindings-view/test/CopyCommandTitle.test.ts
+++ b/packages/keybindings-view/test/CopyCommandTitle.test.ts
@@ -7,6 +7,14 @@ import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaul
 test('copyCommandTitle - writes focused command title to clipboard', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'ClipBoard.writeText'() {},
+    'Layout.getAllQuickPickMenuEntries'() {
+      return [
+        {
+          id: 'ActivityBar.focusNext',
+          label: 'ActivityBar: Focus Next',
+        },
+      ]
+    },
   })
 
   const state: KeyBindingsState = {
@@ -14,7 +22,7 @@ test('copyCommandTitle - writes focused command title to clipboard', async () =>
     focusedIndex: 0,
     items: [
       {
-        command: 'Test: Copy Title',
+        command: 'ActivityBar.focusNext',
         commandMatches: [],
         isCtrl: false,
         isShift: false,
@@ -28,13 +36,47 @@ test('copyCommandTitle - writes focused command title to clipboard', async () =>
 
   const result: KeyBindingsState = await CopyCommandTitle.copyCommandTitle(state)
 
-  expect(mockRpc.invocations).toEqual([['ClipBoard.writeText', 'Test: Copy Title']])
+  expect(mockRpc.invocations).toEqual([['Layout.getAllQuickPickMenuEntries'], ['ClipBoard.writeText', 'ActivityBar: Focus Next']])
+  expect(result).toBe(state)
+})
+
+test('copyCommandTitle - falls back to command id when title is unavailable', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({
+    'ClipBoard.writeText'() {},
+    'Layout.getAllQuickPickMenuEntries'() {
+      return []
+    },
+  })
+
+  const state: KeyBindingsState = {
+    ...createDefaultState(),
+    focusedIndex: 0,
+    items: [
+      {
+        command: 'test.command',
+        commandMatches: [],
+        isCtrl: false,
+        isShift: false,
+        key: 'A',
+        keyMatches: [],
+        rawKey: 0,
+        when: 0,
+      },
+    ],
+  }
+
+  const result: KeyBindingsState = await CopyCommandTitle.copyCommandTitle(state)
+
+  expect(mockRpc.invocations).toEqual([['Layout.getAllQuickPickMenuEntries'], ['ClipBoard.writeText', 'test.command']])
   expect(result).toBe(state)
 })
 
 test('copyCommandTitle - no focused item does nothing', async () => {
-  RendererWorker.registerMockRpc({
+  using mockRpc = RendererWorker.registerMockRpc({
     'ClipBoard.writeText'() {
+      throw new Error('should not be called')
+    },
+    'Layout.getAllQuickPickMenuEntries'() {
       throw new Error('should not be called')
     },
   })
@@ -47,5 +89,6 @@ test('copyCommandTitle - no focused item does nothing', async () => {
 
   const result: KeyBindingsState = await CopyCommandTitle.copyCommandTitle(state)
 
+  expect(mockRpc.invocations).toEqual([])
   expect(result).toBe(state)
 })


### PR DESCRIPTION
Fix Copy Command Title to resolve the registered command label while preserving a command-ID fallback. Strengthen the copy-command e2e coverage so command IDs and titles are asserted as distinct clipboard values.