### PR TITLE
feature: add 40 keybindings e2e tests

### DIFF
--- a/packages/e2e/src/keybindings.alternating-row-styles.ts
+++ b/packages/e2e/src/keybindings.alternating-row-styles.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.alternating-row-styles'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0)).toHaveClass('TableRowEven')
+  await api.expect(api.Locator('.TableBody .TableRow').nth(1)).toHaveClass('TableRowOdd')
+}

--- a/packages/e2e/src/keybindings.clear-button-disabled-after-clear.ts
+++ b/packages/e2e/src/keybindings.clear-button-disabled-after-clear.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.clear-button-disabled-after-clear'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  await api.KeyBindingsEditor.clearInput()
+
+  const button = api.Locator('[name="ClearSearchInput"]')
+  await api.expect(button).toHaveClass('SearchFieldButtonDisabled')
+}

--- a/packages/e2e/src/keybindings.clear-button-disabled.ts
+++ b/packages/e2e/src/keybindings.clear-button-disabled.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.clear-button-disabled'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+
+  const button = api.Locator('[name="ClearSearchInput"]')
+  await api.expect(button).toHaveClass('SearchFieldButtonDisabled')
+  await api.expect(button).toHaveAttribute('title', 'Clear Search Input')
+}

--- a/packages/e2e/src/keybindings.clear-button-enabled.ts
+++ b/packages/e2e/src/keybindings.clear-button-enabled.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.clear-button-enabled'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  const button = api.Locator('[name="ClearSearchInput"]')
+  await api.expect(button).toHaveClass('SearchFieldButton')
+}

--- a/packages/e2e/src/keybindings.clear-then-refilter.ts
+++ b/packages/e2e/src/keybindings.clear-then-refilter.ts
@@ -1,0 +1,16 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.clear-then-refilter'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  await api.KeyBindingsEditor.clearInput()
+  await api.KeyBindingsEditor.handleInput('About.handleClickClose')
+
+  const input = api.Locator('.KeyBindingsSearchInputBox')
+  await api.expect(input).toHaveValue('About.handleClickClose')
+  await api.expect(api.Locator('.TableBody .TableRow')).toHaveCount(1)
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1)).toHaveText('About.handleClickClose')
+}

--- a/packages/e2e/src/keybindings.edit-buttons.ts
+++ b/packages/e2e/src/keybindings.edit-buttons.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.edit-buttons'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  const buttons = api.Locator('.TableBody .KeyBindingsEditButton')
+  await api.expect(buttons).toHaveCount(2)
+  await api.expect(buttons.first()).toHaveAttribute('title', 'Edit')
+}

--- a/packages/e2e/src/keybindings.exact-key-escape.ts
+++ b/packages/e2e/src/keybindings.exact-key-escape.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.exact-key-escape'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('"Escape"')
+
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1)).toHaveText('About.handleClickClose')
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(2)).toHaveText('Escape')
+}

--- a/packages/e2e/src/keybindings.exact-key-no-highlights.ts
+++ b/packages/e2e/src/keybindings.exact-key-no-highlights.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.exact-key-no-highlights'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('"Shift + Tab"')
+
+  const highlights = api.Locator('.TableBody .SearchHighlight')
+  await api.expect(highlights).toHaveCount(0)
+}

--- a/packages/e2e/src/keybindings.exact-key-shift-tab.ts
+++ b/packages/e2e/src/keybindings.exact-key-shift-tab.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.exact-key-shift-tab'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('"Shift + Tab"')
+
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1)).toHaveText('About.focusPrevious')
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(2)).toHaveText('Shift+Tab')
+}

--- a/packages/e2e/src/keybindings.exact-key-tab.ts
+++ b/packages/e2e/src/keybindings.exact-key-tab.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.exact-key-tab'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('"Tab"')
+
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1)).toHaveText('About.focusNext')
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(2)).toHaveText('Tab')
+}

--- a/packages/e2e/src/keybindings.filter-case-insensitive.ts
+++ b/packages/e2e/src/keybindings.filter-case-insensitive.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.filter-case-insensitive'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('about.focusnext')
+
+  await api.expect(api.Locator('.TableBody .TableRow')).toHaveCount(1)
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1)).toHaveText('About.focusNext')
+}

--- a/packages/e2e/src/keybindings.filter-command-highlights.ts
+++ b/packages/e2e/src/keybindings.filter-command-highlights.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.filter-command-highlights'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('about.next')
+
+  const highlights = api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1).locator('.SearchHighlight')
+  await api.expect(highlights).toHaveCount(2)
+  await api.expect(highlights.nth(0)).toHaveText('About.')
+  await api.expect(highlights.nth(1)).toHaveText('Next')
+}

--- a/packages/e2e/src/keybindings.filter-focus-next-exact.ts
+++ b/packages/e2e/src/keybindings.filter-focus-next-exact.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.filter-focus-next-exact'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focusNext')
+
+  await api.expect(api.Locator('.TableBody .TableRow')).toHaveCount(1)
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1)).toHaveText('About.focusNext')
+}

--- a/packages/e2e/src/keybindings.filter-focus-previous-exact.ts
+++ b/packages/e2e/src/keybindings.filter-focus-previous-exact.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.filter-focus-previous-exact'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focusPrevious')
+
+  await api.expect(api.Locator('.TableBody .TableRow')).toHaveCount(1)
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1)).toHaveText('About.focusPrevious')
+}

--- a/packages/e2e/src/keybindings.filter-fuzzy-segments.ts
+++ b/packages/e2e/src/keybindings.filter-fuzzy-segments.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.filter-fuzzy-segments'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('about.next')
+
+  await api.expect(api.Locator('.TableBody .TableRow')).toHaveCount(1)
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1)).toHaveText('About.focusNext')
+}

--- a/packages/e2e/src/keybindings.filter-handle-click-close.ts
+++ b/packages/e2e/src/keybindings.filter-handle-click-close.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.filter-handle-click-close'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.handleClickClose')
+
+  await api.expect(api.Locator('.TableBody .TableRow')).toHaveCount(1)
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1)).toHaveText('About.handleClickClose')
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(2)).toHaveText('Escape')
+}

--- a/packages/e2e/src/keybindings.filtered-command-column.ts
+++ b/packages/e2e/src/keybindings.filtered-command-column.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.filtered-command-column'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1)).toHaveText('About.focusNext')
+  await api.expect(api.Locator('.TableBody .TableRow').nth(1).locator('.TableCell').nth(1)).toHaveText('About.focusPrevious')
+}

--- a/packages/e2e/src/keybindings.filtered-keybinding-column.ts
+++ b/packages/e2e/src/keybindings.filtered-keybinding-column.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.filtered-keybinding-column'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(2)).toHaveText('Tab')
+  await api.expect(api.Locator('.TableBody .TableRow').nth(1).locator('.TableCell').nth(2)).toHaveText('Shift+Tab')
+}

--- a/packages/e2e/src/keybindings.filtered-row-count-accessibility.ts
+++ b/packages/e2e/src/keybindings.filtered-row-count-accessibility.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.filtered-row-count-accessibility'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  const table = api.Locator('.Table')
+  await api.expect(table).toHaveAttribute('aria-rowcount', '2')
+}

--- a/packages/e2e/src/keybindings.filtered-row-indexes.ts
+++ b/packages/e2e/src/keybindings.filtered-row-indexes.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.filtered-row-indexes'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0)).toHaveAttribute('aria-rowindex', '2')
+  await api.expect(api.Locator('.TableBody .TableRow').nth(1)).toHaveAttribute('aria-rowindex', '3')
+}

--- a/packages/e2e/src/keybindings.filtered-source-column.ts
+++ b/packages/e2e/src/keybindings.filtered-source-column.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.filtered-source-column'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(4)).toHaveText('System')
+  await api.expect(api.Locator('.TableBody .TableRow').nth(1).locator('.TableCell').nth(4)).toHaveText('System')
+}

--- a/packages/e2e/src/keybindings.filtered-when-column.ts
+++ b/packages/e2e/src/keybindings.filtered-when-column.ts
@@ -1,0 +1,11 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.filtered-when-column'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(3)).toHaveText('FocusAbout')
+  await api.expect(api.Locator('.TableBody .TableRow').nth(1).locator('.TableCell').nth(3)).toHaveText('FocusAbout')
+}

--- a/packages/e2e/src/keybindings.focus-input-after-selection.ts
+++ b/packages/e2e/src/keybindings.focus-input-after-selection.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.focus-input-after-selection'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+  await api.Command.execute('KeyBindings.handleClickIndex', 1, false)
+
+  await api.Command.execute('KeyBindings.focusInput')
+
+  await api.expect(api.Locator('.KeyBindingsSearchInputBox')).toBeFocused()
+}

--- a/packages/e2e/src/keybindings.focus-input-command.ts
+++ b/packages/e2e/src/keybindings.focus-input-command.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.focus-input-command'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+
+  await api.Command.execute('KeyBindings.focusInput')
+
+  const input = api.Locator('.KeyBindingsSearchInputBox')
+  await api.expect(input).toBeFocused()
+}

--- a/packages/e2e/src/keybindings.header-row-index.ts
+++ b/packages/e2e/src/keybindings.header-row-index.ts
@@ -1,0 +1,10 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.header-row-index'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+
+  const headerRow = api.Locator('.TableHead .TableRow')
+  await api.expect(headerRow).toHaveAttribute('aria-rowindex', '1')
+}

--- a/packages/e2e/src/keybindings.no-results-recovery.ts
+++ b/packages/e2e/src/keybindings.no-results-recovery.ts
@@ -1,0 +1,15 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.no-results-recovery'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('no-command-can-match-this-value')
+  await api.expect(api.Locator('.TableBody .TableRow')).toHaveCount(0)
+
+  await api.KeyBindingsEditor.handleInput('About.focusNext')
+
+  await api.expect(api.Locator('.TableBody .TableRow')).toHaveCount(1)
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1)).toHaveText('About.focusNext')
+  await api.expect(api.Locator('.NoMatchingKeyBindingsFoundMessage')).toHaveCount(0)
+}

--- a/packages/e2e/src/keybindings.record-button-semantics.ts
+++ b/packages/e2e/src/keybindings.record-button-semantics.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.record-button-semantics'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+
+  const button = api.Locator('[name="RecordKeys"]')
+  await api.expect(button).toHaveAttribute('role', 'checkbox')
+  await api.expect(button).toHaveAttribute('aria-checked', 'false')
+  await api.expect(button).toHaveAttribute('title', 'Record keys')
+}

--- a/packages/e2e/src/keybindings.record-key.ts
+++ b/packages/e2e/src/keybindings.record-key.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.record-key'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.startRecordingKeys()
+
+  await api.Command.execute('KeyBindings.handleKeyDown', false, false, 'x')
+
+  const input = api.Locator('.KeyBindingsSearchInputBox')
+  await api.expect(input).toHaveValue(' x')
+  await api.expect(api.Locator('[name="RecordKeys"]')).toHaveAttribute('aria-checked', 'true')
+}

--- a/packages/e2e/src/keybindings.recording-escape.ts
+++ b/packages/e2e/src/keybindings.recording-escape.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.recording-escape'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.startRecordingKeys()
+
+  await api.Command.execute('KeyBindings.handleKeyDown', false, false, 'Escape')
+
+  const button = api.Locator('[name="RecordKeys"]')
+  await api.expect(button).toHaveAttribute('aria-checked', 'false')
+  await api.expect(api.Locator('.InputBadge')).toHaveCount(0)
+}

--- a/packages/e2e/src/keybindings.search-actions.ts
+++ b/packages/e2e/src/keybindings.search-actions.ts
@@ -1,0 +1,10 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.search-actions'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+
+  const actions = api.Locator('.KeyBindingsSearchButtons .SearchFieldButton')
+  await api.expect(actions).toHaveCount(3)
+}

--- a/packages/e2e/src/keybindings.search-input-autocomplete.ts
+++ b/packages/e2e/src/keybindings.search-input-autocomplete.ts
@@ -1,0 +1,10 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.search-input-autocomplete'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+
+  const input = api.Locator('.KeyBindingsSearchInputBox')
+  await api.expect(input).toHaveAttribute('autocomplete', 'off')
+}

--- a/packages/e2e/src/keybindings.search-input-name.ts
+++ b/packages/e2e/src/keybindings.search-input-name.ts
@@ -1,0 +1,10 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.search-input-name'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+
+  const input = api.Locator('.KeyBindingsSearchInputBox')
+  await api.expect(input).toHaveAttribute('name', 'keybindings-filter')
+}

--- a/packages/e2e/src/keybindings.select-first-row.ts
+++ b/packages/e2e/src/keybindings.select-first-row.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.select-first-row'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  await api.Command.execute('KeyBindings.handleClickIndex', 0, false)
+
+  await api.expect(api.Locator('.TableBody .TableRow').nth(0)).toHaveClass('TableRowSelected')
+  await api.expect(api.Locator('.Table')).toBeFocused()
+}

--- a/packages/e2e/src/keybindings.select-second-row.ts
+++ b/packages/e2e/src/keybindings.select-second-row.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.select-second-row'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.handleInput('About.focus')
+
+  await api.Command.execute('KeyBindings.handleClickIndex', 1, false)
+
+  await api.expect(api.Locator('.TableBody .TableRow').nth(1)).toHaveClass('TableRowSelected')
+  await api.expect(api.Locator('.Table')).toBeFocused()
+}

--- a/packages/e2e/src/keybindings.sort-button-semantics.ts
+++ b/packages/e2e/src/keybindings.sort-button-semantics.ts
@@ -1,0 +1,12 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.sort-button-semantics'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+
+  const button = api.Locator('[name="SortByPrecdence"]')
+  await api.expect(button).toHaveAttribute('role', 'checkbox')
+  await api.expect(button).toHaveAttribute('aria-checked', 'false')
+  await api.expect(button).toHaveAttribute('title', 'Sort By Precedence')
+}

--- a/packages/e2e/src/keybindings.sort-by-precedence-off.ts
+++ b/packages/e2e/src/keybindings.sort-by-precedence-off.ts
@@ -1,0 +1,14 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.sort-by-precedence-off'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+  await api.KeyBindingsEditor.sortByPrecedence()
+
+  await api.KeyBindingsEditor.sortByPrecedence()
+
+  const button = api.Locator('[name="SortByPrecdence"]')
+  await api.expect(button).toHaveAttribute('aria-checked', 'false')
+  await api.expect(button).toHaveClass('SearchFieldButton')
+}

--- a/packages/e2e/src/keybindings.sort-by-precedence-on.ts
+++ b/packages/e2e/src/keybindings.sort-by-precedence-on.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.sort-by-precedence-on'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+
+  await api.KeyBindingsEditor.sortByPrecedence()
+
+  const button = api.Locator('[name="SortByPrecdence"]')
+  await api.expect(button).toHaveAttribute('aria-checked', 'true')
+  await api.expect(button).toHaveClass('SearchFieldButtonChecked')
+}

--- a/packages/e2e/src/keybindings.table-focusable.ts
+++ b/packages/e2e/src/keybindings.table-focusable.ts
@@ -1,0 +1,10 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.table-focusable'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+
+  const table = api.Locator('.Table')
+  await api.expect(table).toHaveAttribute('tabindex', '0')
+}

--- a/packages/e2e/src/keybindings.toggle-recording-on.ts
+++ b/packages/e2e/src/keybindings.toggle-recording-on.ts
@@ -1,0 +1,13 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.toggle-recording-on'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+
+  await api.KeyBindingsEditor.toggleRecordingKeys()
+
+  const button = api.Locator('[name="RecordKeys"]')
+  await api.expect(button).toHaveAttribute('aria-checked', 'true')
+  await api.expect(api.Locator('.InputBadge')).toHaveText('Recording keys')
+}

--- a/packages/e2e/src/keybindings.view-document-role.ts
+++ b/packages/e2e/src/keybindings.view-document-role.ts
@@ -1,0 +1,10 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.view-document-role'
+
+export const test: Test = async (api) => {
+  await api.KeyBindingsEditor.open()
+
+  const view = api.Locator('.Viewlet.KeyBindings')
+  await api.expect(view).toHaveAttribute('role', 'document')
+}


### PR DESCRIPTION
Adds 40 active end-to-end scenarios for the keybindings view.

Coverage includes filtering, exact key searches, accessibility semantics, row selection and focus, sorting, and key recording.