### PR TITLE
fix: complete keybinding mutations

### DIFF
--- a/keybindings-view-issues/README.md
+++ b/keybindings-view-issues/README.md
@@ -36,7 +36,8 @@
 | [Record Keys drops shortcut modifiers](record-keys-drops-modifiers/README.md)       | Fixed and verified |
 | [Filter drops characters during fast typing](filter-drops-fast-input/README.md)     | Fixed and verified |
 | [Source column is never visible](source-column-not-visible/README.md)               | Fixed and verified |
-| [Keybinding mutations do not apply](keybinding-mutations-do-not-apply/README.md)    | Fixed locally      |
+| [Keybinding mutations do not apply](keybinding-mutations-do-not-apply/README.md)    | Fixed and verified |
 | [No-results filter has no empty-state message](no-results-has-no-message/README.md) | Fixed and verified |
 
-“Fixed locally” means both repository halves have passing regression tests; the combined browser fixture requires the corresponding `keybindings-view` and `lvce-editor` updates to be released together.
+The final combined build uses `@lvce-editor/server` 0.94.6. Its full browser
+suite passed with 64 tests passing, 6 intentionally skipped, and no failures.

--- a/keybindings-view-issues/keybinding-mutations-do-not-apply/README.md
+++ b/keybindings-view-issues/keybinding-mutations-do-not-apply/README.md
@@ -42,4 +42,19 @@ Add and Remove were each reproduced on `About.handleClickClose` and `Chat.handle
 
 ## Resolution
 
-Add and Change now open an explicit capture mode, the captured shortcut is parsed (including Alt), Add creates a `User` binding, Change replaces the selected row, and Remove deletes it. A companion `lvce-editor` fix submits the recorded value instead of the literal Enter key and dispatches the result through the normal render pipeline. The worker mutations, widget opening, and host handoff have passing regression tests.
+Add and Change now open an explicit capture mode, the captured shortcut is
+parsed (including Alt), Add creates a `User` binding, Change replaces the
+selected row, and Remove deletes it.
+
+The final failure was in the dialog-to-parent handoff across the two
+repositories:
+
+- `keybindings-view` now supplies its runtime view UID when opening the capture
+  dialog.
+- `lvce-editor` 0.94.6 stores that parent UID, resolves numeric runtime UIDs
+  correctly, and waits for dialog disposal before completing the Enter command.
+- Dedicated browser regressions cover add/remove, change, and showing all
+  bindings with the same shortcut.
+
+The exact combined build passed all 64 enabled browser tests, with 6
+intentionally skipped and no failures.

--- a/package-lock.json
+++ b/package-lock.json
@@ -2891,6 +2891,18 @@
       "integrity": "sha512-l9fHl7KDYAm4ou/B88fiRYVguA7z5Fx4lC8SmCLuCJFeXfjqPFh7rnGysToPNssmcPAEdwOgXvH+5U4v2V6q5Q==",
       "license": "MIT"
     },
+    "node_modules/@lvce-editor/auth-process": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/auth-process/-/auth-process-1.12.0.tgz",
+      "integrity": "sha512-lLA01IwXTKdTWXg1ydpsdjHilY3LDT6Ud5DWWaZ6uPwmhTeSIpQ5BP+Fu+8hlZYMW4gUyuFtuYjtDV88S5dF4A==",
+      "license": "MIT",
+      "bin": {
+        "auth-process": "bin/oauthProcess.js"
+      },
+      "engines": {
+        "node": ">=24"
+      }
+    },
     "node_modules/@lvce-editor/command": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/command/-/command-2.0.0.tgz",
@@ -2898,15 +2910,15 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/constants": {
-      "version": "5.19.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.19.0.tgz",
-      "integrity": "sha512-E+uV4TNbCXTjDqIyAoDC7HDBVlEXOLM1jCLXMmkT83m+TQr8tTehGY5nMfKSBBZI+DMe9NgUdA5NBJH43jXJOw==",
+      "version": "5.23.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.23.0.tgz",
+      "integrity": "sha512-hjkqo7QLQl7pL2c+rH54q0/8dSpKDSfF6/3BvBAS2NsSpvtCnab3Ew4bhVyMJrw1c9RnwcC2pmy6iDPtPpz0IQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/embeds-process": {
-      "version": "4.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.4.0.tgz",
-      "integrity": "sha512-odCuJeGo/yKntWBVT5voyETm+oJv4KPDEVn1Owq21CFP8N3lx2FXwUO7l92X65KH3t0T8zBgfyxKBaxF17dksw==",
+      "version": "4.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/embeds-process/-/embeds-process-4.12.0.tgz",
+      "integrity": "sha512-U+2zOHT1RFRAoMZUxrtzIdkL7P7MyMWmU+378fsTuW4D0YMoVZPnUBT95SpHvTxv0u2gQikrPHUMEBQIf0SI1Q==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -3034,16 +3046,16 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.78.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.78.0.tgz",
-      "integrity": "sha512-AIWTl+5Z34Uh9GnerMbDQibnydUm7kVk1kxCsocPG3g0M2VaRg0pTuyDfl8PTFIYGB5FZT1aLBv44StBLRvSRA==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.94.6.tgz",
+      "integrity": "sha512-h1iqsQz9XZFl5pF/NbQow7iL44fN+0kCQP0CfPyQ89IWPzdQaFwJN1/clwQqKr+qNFWrD8Ss9fg37vnu6P8zsw==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/rpc": "^6.4.0",
+        "@lvce-editor/assert": "^1.7.0",
+        "@lvce-editor/rpc": "^6.11.0",
         "@lvce-editor/verror": "^1.7.0",
         "execa": "^9.6.1",
-        "got": "^15.0.1",
+        "got": "^15.1.0",
         "minimist": "^1.2.8"
       },
       "engines": {
@@ -3051,14 +3063,14 @@
       }
     },
     "node_modules/@lvce-editor/file-system-process": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.0.0.tgz",
-      "integrity": "sha512-0RYnjIZMxYYpSQ4hxjo0K+qQXbWU/3+bVx9jEu8102CcSMpitRUH2XiGqH+tRHVtcvUmz8JQCP1cDQVVlrOh8A==",
+      "version": "5.7.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-system-process/-/file-system-process-5.7.0.tgz",
+      "integrity": "sha512-tA0GKQ1xwl38YivgPLbCfaYQ/D+EUzL9xn2sOp0yc9imIz6Tf49acI0jLD0/iAodbqeBX6EzjSWRXqXnpa4ygg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "trash": "^10.1.0",
-        "ws": "^8.19.0"
+        "trash": "^10.1.1",
+        "ws": "^8.21.1"
       },
       "bin": {
         "file-system-process": "bin/fileSystemProcess.js"
@@ -3068,14 +3080,14 @@
       }
     },
     "node_modules/@lvce-editor/file-watcher-process": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-3.6.0.tgz",
-      "integrity": "sha512-EqijIFxF8PoYWhnYpCjwueOz202vid4NpfX1KbW79hkVKOCTe7BlWg5z17K8BbEpP7F0VIUnpiy5mwOoMPoqMw==",
+      "version": "4.8.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/file-watcher-process/-/file-watcher-process-4.8.0.tgz",
+      "integrity": "sha512-+Bk/ocB9rrLlHOlNsnpJ9ixg4NO63WaNoGVX6PRroRXstIKiRXQvFVxVmw7qG8Y9uwAsT0EN5qdCOE77AcHBxA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@lvce-editor/assert": "^1.4.0",
-        "chokidar": "^4.0.3"
+        "@lvce-editor/assert": "^1.5.1",
+        "chokidar": "^5.0.0"
       },
       "bin": {
         "file-watcher-process": "bin/fileWatcherProcess.js"
@@ -3085,9 +3097,9 @@
       }
     },
     "node_modules/@lvce-editor/ipc": {
-      "version": "16.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.4.0.tgz",
-      "integrity": "sha512-CxMjWxF/NjoAwa2B5/hFzuXuPVSSTY2tM4khlLopXTqIHbkPJzo6FAAkBI8NRqabchRYCDDpvaO+IvASWwp+Zw==",
+      "version": "16.6.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-16.6.0.tgz",
+      "integrity": "sha512-DYP2n651sgxPq6ovBDsuKFo+SnuS6/ipEH64DZGFaBjNJ+PFUrUHq+5gZiUgBM9GifGkyTKFSGL7eq4K5/EETg==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
@@ -3099,9 +3111,9 @@
       }
     },
     "node_modules/@lvce-editor/json-rpc": {
-      "version": "8.3.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.3.0.tgz",
-      "integrity": "sha512-P05TN3OvSVP0LkcG8xE79mGom/i89ttEJq3RfqRwv0sKvSi77NEp9JU3NGANNtBkbFuNWr8s6+XmSmhcj/3ahg==",
+      "version": "8.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.5.0.tgz",
+      "integrity": "sha512-cBL4jq/DFnbZdyFMk/+nhb3+e4fEPrtyHt0eKPcWb/cauBH5cbju1fwEfmDcT+8oA44ILcF2NoqZ7jnuEeFRgQ==",
       "license": "MIT"
     },
     "node_modules/@lvce-editor/jsonc-parser": {
@@ -3154,45 +3166,6 @@
       },
       "funding": {
         "url": "https://github.com/sindresorhus/is?sponsor=1"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/array-union": {
-      "version": "1.0.2",
-      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
-      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "array-uniq": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/dir-glob": {
-      "version": "2.2.2",
-      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
-      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "path-type": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=4"
       }
     },
     "node_modules/@lvce-editor/network-process/node_modules/glob": {
@@ -3269,35 +3242,6 @@
       "license": "MIT",
       "optional": true
     },
-    "node_modules/@lvce-editor/network-process/node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/network-process/node_modules/keyv": {
       "version": "5.6.0",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-5.6.0.tgz",
@@ -3319,19 +3263,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "license": "ISC",
-      "optional": true,
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/@lvce-editor/network-process/node_modules/move-file": {
@@ -3362,19 +3293,6 @@
         "is-inside-container": "^1.0.0",
         "wsl-utils": "^0.1.0"
       },
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/network-process/node_modules/p-map": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
-      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
-      "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=18"
       },
@@ -3483,15 +3401,6 @@
         "lines-and-columns": "^2.0.4"
       }
     },
-    "node_modules/@lvce-editor/pretty-error/node_modules/lines-and-columns": {
-      "version": "2.0.4",
-      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
-      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
-      "license": "MIT",
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
     "node_modules/@lvce-editor/preview-process": {
       "version": "11.0.0",
       "resolved": "https://registry.npmjs.org/@lvce-editor/preview-process/-/preview-process-11.0.0.tgz",
@@ -3508,10 +3417,25 @@
         "node": ">=22"
       }
     },
+    "node_modules/@lvce-editor/process-explorer": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/process-explorer/-/process-explorer-3.12.0.tgz",
+      "integrity": "sha512-BrGgUrk7BwWS5hm6KczqksVD9bIYVMjaQh2njxt3ZDn2dURXAcNtyfWJlnXelAw7ccUWJXNaS0GlUZxPVG7aXA==",
+      "license": "MIT",
+      "bin": {
+        "process-explorer": "bin/processExplorer.js"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "optionalDependencies": {
+        "@vscode/windows-process-tree": "^0.8.0"
+      }
+    },
     "node_modules/@lvce-editor/pty-host": {
-      "version": "8.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.1.0.tgz",
-      "integrity": "sha512-RhaALocF9dTRbXfYctmWX23KFNf8R/mCRA8FSiBsCbJQ8zYTUiN5SUgMVBT3MsVS09kWfcOptFIAaq+1WEzexw==",
+      "version": "8.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/pty-host/-/pty-host-8.4.0.tgz",
+      "integrity": "sha512-Ka/MkHduJi6N/42FQuA+Qiz41HzmRnuXiyABZTENQi9/HE/Z+PrXQ92RDpSh9El4lrLX0JNMvhnk2EqgqcJw/Q==",
       "license": "MIT",
       "optional": true,
       "bin": {
@@ -3522,158 +3446,52 @@
       }
     },
     "node_modules/@lvce-editor/ripgrep": {
-      "version": "4.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-4.1.0.tgz",
-      "integrity": "sha512-J57lVXxRIbyuz1YwOi/hiUOMF6KDuOvht5OkhxVQOU971uv3j2t5bNdD6flq0hKmWESlr18p6sO0RTj8WMDIEA==",
-      "hasInstallScript": true,
+      "version": "5.4.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/ripgrep/-/ripgrep-5.4.0.tgz",
+      "integrity": "sha512-9Y6xyk24MuVwz6WDv9SWyxVC351x1H/yHr2yaU5iuf0snnlGKOX4ix/QpniiESDHjlJn74B2V/h6DI4kwxckkQ==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@lvce-editor/verror": "^1.7.0",
-        "execa": "^9.6.0",
-        "extract-zip": "^2.0.1",
-        "fs-extra": "^11.3.2",
-        "path-exists": "^5.0.0",
-        "tempy": "^3.1.0",
-        "xdg-basedir": "^5.1.0"
+        "@vscode/ripgrep": "1.18.0"
       },
       "engines": {
         "node": ">=22"
       }
     },
-    "node_modules/@lvce-editor/ripgrep/node_modules/crypto-random-string": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/crypto-random-string/-/crypto-random-string-4.0.0.tgz",
-      "integrity": "sha512-x8dy3RnvYdlUcPOjkEHqozhiwzKNSq7GcPuXFbnyMOCHxX8V3OgIg/pYuabl2sbUPfIJaeAQB7PMOK8DFIdoRA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "type-fest": "^1.0.1"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/crypto-random-string/node_modules/type-fest": {
-      "version": "1.4.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-1.4.0.tgz",
-      "integrity": "sha512-yGSza74xk0UG8k+pLh5oeoYirvIiWo5t0/o3zHHAO2tRDiZcxWP7fywNlXhqb6/r6sWvwi+RsyQMWhVLe4BVuA==",
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/path-exists": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-5.0.0.tgz",
-      "integrity": "sha512-RjhtfwJOxzcFmNOi6ltcbcu4Iu+FL3zEj83dk4kAS+fVpTxXLO1b38RvJgT/0QwvV/L3aY9TAnyv0EOqW4GoMQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/temp-dir": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/temp-dir/-/temp-dir-3.0.0.tgz",
-      "integrity": "sha512-nHc6S/bwIilKHNRgK/3jlhDoIHcp45YgyiwcAk46Tr0LfEqGBVpmiAyuiuxeVE44m3mXnEeVhaipLOEWmH+Njw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14.16"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/tempy": {
-      "version": "3.2.0",
-      "resolved": "https://registry.npmjs.org/tempy/-/tempy-3.2.0.tgz",
-      "integrity": "sha512-d79HhZya5Djd7am0q+W4RTsSU+D/aJzM+4Y4AGJGuGlgM2L6sx5ZvOYTmZjqPhrDrV6xJTtRSm1JCLj6V6LHLQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-stream": "^3.0.0",
-        "temp-dir": "^3.0.0",
-        "type-fest": "^2.12.2",
-        "unique-string": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=14.16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/tempy/node_modules/is-stream": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-stream/-/is-stream-3.0.0.tgz",
-      "integrity": "sha512-LnQR4bZ9IADDRSkvpqMGvt/tEJWclzklNgSw48V5EAaAeDd6qGvN8ei6k5p0tvxSR171VmGyHuTiAOfxAbr8kA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/type-fest": {
-      "version": "2.19.0",
-      "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-2.19.0.tgz",
-      "integrity": "sha512-RAH822pAdBgcNMAfWnCBU3CFZcfZ/i1eZjwFU/dsLKumyuuP3niueg2UAukXYF0E2AAoc82ZSSf9J0WQBinzHA==",
-      "license": "(MIT OR CC0-1.0)",
-      "optional": true,
-      "engines": {
-        "node": ">=12.20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/ripgrep/node_modules/unique-string": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-3.0.0.tgz",
-      "integrity": "sha512-VGXBUVwxKMBUznyffQweQABPRRW1vHZAbadFZud4pLFAqRGvv/96vafgjWFqzourzr8YonlQiPgH0YCJfawoGQ==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "crypto-random-string": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/rpc": {
-      "version": "6.8.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.8.0.tgz",
-      "integrity": "sha512-oazWvr0qLlBJCzHrRhMSziDU7k4poyj8ufyq+HKEb8gLtWqPCRBdSPtik3f8ORaCvZiv5IESLcFzlhJR/l4Ktw==",
+      "version": "6.11.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.11.0.tgz",
+      "integrity": "sha512-Hvte166d7Hjf8roIx5Z4ZRSS5sQZUEa7lkw20yjfp2MeOp4GQO9XAUL+2ca7J6wtPfIAYRlEL3av4YAYztoLIw==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.5.1",
         "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^16.3.0",
-        "@lvce-editor/json-rpc": "^8.1.0",
+        "@lvce-editor/ipc": "^16.4.0",
+        "@lvce-editor/json-rpc": "^8.4.0",
         "@lvce-editor/verror": "^1.7.0"
       }
     },
+    "node_modules/@lvce-editor/rpc-registry": {
+      "version": "9.42.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.42.0.tgz",
+      "integrity": "sha512-5/G0T87nC3aKRujuLJSpSsG0jPdXmrwDqRX3rHNmUWh7FaMPC0SoqBqenMTy2V+EHqnX0LRFyC6FO5LPwoPFgQ==",
+      "license": "MIT",
+      "dependencies": {
+        "@lvce-editor/assert": "^1.5.1",
+        "@lvce-editor/constants": "^5.22.0",
+        "@lvce-editor/rpc": "^6.4.0"
+      }
+    },
     "node_modules/@lvce-editor/search-process": {
-      "version": "13.1.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-13.1.0.tgz",
-      "integrity": "sha512-A4W+vb0UPkh8ZpeFf06LKeU7uJDnvI5ZnV0jsxbaPdp6y3icWPxOp6aYYpZierRHKgApuzjlP/eXbgfdKCf7UQ==",
+      "version": "15.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/search-process/-/search-process-15.2.0.tgz",
+      "integrity": "sha512-UY8msa5Tlb/mWg1pQV6ZtvI7TQ3Rz7NvTDpq2Z/NCqobKQLUe4yBMq4yEufXL/5tQBzLjumBCReBtc2usqyy2w==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@lvce-editor/constants": "^3.7.0",
-        "execa": "^9.6.0",
-        "ws": "^8.18.3"
+        "@lvce-editor/constants": "^5.14.0",
+        "execa": "^9.6.1",
+        "ws": "^8.21.1"
       },
       "bin": {
         "search-process": "bin/searchProcess.js"
@@ -3682,24 +3500,17 @@
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/ripgrep": "^4.0.0"
+        "@lvce-editor/ripgrep": "^5.2.0"
       }
     },
-    "node_modules/@lvce-editor/search-process/node_modules/@lvce-editor/constants": {
-      "version": "3.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-3.7.0.tgz",
-      "integrity": "sha512-NTxt0cZlacI63ZryyoMFh1Nw717jyWpTIqnoaK7ssNBDjAWuEmIdNTcJq2ZyAtGkcJReuq1XHzbjAE5o44O0ow==",
-      "license": "MIT",
-      "optional": true
-    },
     "node_modules/@lvce-editor/server": {
-      "version": "0.78.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.78.0.tgz",
-      "integrity": "sha512-r8p78d4wwpYzw+WTiKPv3OD4g47CK7WPI9+dckHSZe95ZymB63Z2XpuqpR+iYRYq5ro0jejo3hUNwRxwbb/DRg==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.94.6.tgz",
+      "integrity": "sha512-umEEKyQuYp43ydVnsbJJRjDN3amx9Sa6P5pMNjx3g4E1wzrP6fk4nKUDvCjR4z8NKKWH3NVJ+iC/MjSHpdydFA==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.78.0",
-        "@lvce-editor/static-server": "0.78.0"
+        "@lvce-editor/shared-process": "0.94.6",
+        "@lvce-editor/static-server": "0.94.6"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3709,194 +3520,48 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.78.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.78.0.tgz",
-      "integrity": "sha512-SSolWB/fCaxLPgM5sxCPhszXNka5CnFRfXq2XSOv/fymgTeE0r6b0BpshBEPPkn92GlCQmLJdvwpWf2bkWXVBA==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.94.6.tgz",
+      "integrity": "sha512-1f7px4YLb/4QCV2c67nunMkyX7WO+HcBHzO+ZwN52r8TspeIBOoKsb0ZftgL0wcNyxcGzhTNuSrsTU8eLLsyBg==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/assert": "1.5.1",
-        "@lvce-editor/extension-host-helper-process": "0.78.0",
-        "@lvce-editor/ipc": "15.0.0",
-        "@lvce-editor/json-rpc": "8.0.0",
+        "@lvce-editor/assert": "1.7.0",
+        "@lvce-editor/auth-process": "1.12.0",
+        "@lvce-editor/extension-host-helper-process": "0.94.6",
+        "@lvce-editor/ipc": "16.6.0",
+        "@lvce-editor/json-rpc": "8.5.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
         "@lvce-editor/pretty-error": "2.0.0",
-        "@lvce-editor/rpc-registry": "9.17.0",
+        "@lvce-editor/process-explorer": "3.12.0",
+        "@lvce-editor/rpc-registry": "9.42.0",
         "@lvce-editor/verror": "1.7.0",
         "is-object": "^1.0.2",
+        "markdown-it": "^14.3.0",
         "xdg-basedir": "^5.1.0"
       },
       "engines": {
         "node": ">=24"
       },
       "optionalDependencies": {
-        "@lvce-editor/embeds-process": "4.4.0",
-        "@lvce-editor/file-system-process": "5.0.0",
-        "@lvce-editor/file-watcher-process": "3.6.0",
+        "@lvce-editor/embeds-process": "4.12.0",
+        "@lvce-editor/file-system-process": "5.7.0",
+        "@lvce-editor/file-watcher-process": "4.8.0",
         "@lvce-editor/network-process": "5.2.0",
         "@lvce-editor/preload": "1.5.0",
         "@lvce-editor/preview-process": "11.0.0",
-        "@lvce-editor/pty-host": "8.1.0",
-        "@lvce-editor/search-process": "13.1.0",
-        "@lvce-editor/typescript-compile-process": "5.0.0",
+        "@lvce-editor/pty-host": "8.4.0",
+        "@lvce-editor/search-process": "15.2.0",
+        "@lvce-editor/typescript-compile-process": "5.5.0",
         "open": "^11.0.0",
         "tail": "^2.2.6",
         "tmp-promise": "^3.0.3",
         "trash": "^10.1.1"
       }
     },
-    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/assert": {
-      "version": "1.5.1",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/assert/-/assert-1.5.1.tgz",
-      "integrity": "sha512-euS3PuVVjZy06bPFbgTz1yjQ0mY5BgWeYEDb9eQL2ncqYeap0ADy1D57nddlps1VkhHxj1g2ifXkLeIKLkQYJg==",
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/ipc": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-15.0.0.tgz",
-      "integrity": "sha512-PY8HVhuShfGaTgTSgrsgwgv7Po3WPkgh9AlilgYull4yFPKYZphlGogMSudxq+IsdhKYjD7hdncUEoox+idXiQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/json-rpc": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-8.0.0.tgz",
-      "integrity": "sha512-mjeSYYd0qJ0Jz3vpEucBnikdbIFsdmewDX/EkVLHw7obYh0WUXr9f3u528nVAHskrUpb8/IsZY4ynJ0Uaar9bA==",
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/rpc": {
-      "version": "5.6.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-5.6.0.tgz",
-      "integrity": "sha512-9C/sXlcgTtdSPkmS2xhWaRTcV29HiRI25PY2Ujkp74DVEBJ9tVO2UKz4ZE0XhIAeXojQBJG1wrk2Jmhj7dSiXg==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^14.7.0",
-        "@lvce-editor/json-rpc": "^7.2.0"
-      }
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.17.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.17.0.tgz",
-      "integrity": "sha512-8Cjjgh4EbEyODecUOqheHbpg6zGCKlxgvgD4Q1jicGqts3g4uMrddH4n5T5fjYGBPclzklsrbfhyU1YN1kOLdQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.7.0",
-        "@lvce-editor/rpc": "^5.5.0"
-      }
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/rpc/node_modules/@lvce-editor/ipc": {
-      "version": "14.7.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-14.7.0.tgz",
-      "integrity": "sha512-O/bt6OHcDPBmhkxQNpqA08EoxI8fpEvtpzye5O4GowH08/BvTAsRVocmPFioDNAL1no40vDg0eYFHg0frh1daQ==",
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/@lvce-editor/rpc/node_modules/@lvce-editor/json-rpc": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/json-rpc/-/json-rpc-7.2.0.tgz",
-      "integrity": "sha512-zslYa6B7qzsvVCbSXp9XYDRlPiRVVdFzen1lhNtRbJ4mZxp8IZnbj+YmM8VA4SKnr7m8Ebo9OWwN28sPzjInjQ==",
-      "license": "MIT"
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/define-lazy-prop": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
-      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/open": {
-      "version": "11.0.0",
-      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
-      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "default-browser": "^5.4.0",
-        "define-lazy-prop": "^3.0.0",
-        "is-in-ssh": "^1.0.0",
-        "is-inside-container": "^1.0.0",
-        "powershell-utils": "^0.1.0",
-        "wsl-utils": "^0.3.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/powershell-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/@lvce-editor/shared-process/node_modules/wsl-utils": {
-      "version": "0.3.1",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
-      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-wsl": "^3.1.0",
-        "powershell-utils": "^0.1.0"
-      },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.78.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.78.0.tgz",
-      "integrity": "sha512-sem0nj46yeik2MnrKn3oBmgc4lKsQPsEdcwIwtdWKlwFmmfAY8HIxISwJuA6qSGwjTsp9lD99/aCf5s2NM1F0A==",
+      "version": "0.94.6",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.94.6.tgz",
+      "integrity": "sha512-AlTdD8PhtASGL7j6oNH4I80/3cGdRFj6o+q396/qGYouCatUHiiGkB/yypE0aKHMwCAwmb5kD7c7h2WeUf7WdA==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -3944,14 +3609,11 @@
       "link": true
     },
     "node_modules/@lvce-editor/typescript-compile-process": {
-      "version": "5.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.0.0.tgz",
-      "integrity": "sha512-c6LsNuK5iK0kUXWkJ/cTor4bzixxzSi5/4k/vJ0L300q/1BLkDcua3f+UDs1Q4v9a1i8TTRtxlCvLohUCZoDjQ==",
+      "version": "5.5.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/typescript-compile-process/-/typescript-compile-process-5.5.0.tgz",
+      "integrity": "sha512-MhZNNU/SF2jSALAiyq4335rLM4NznRcfhWbtnx4n9VBLIDngW78K9DwDX7EtnFPTK+YmT60gHXa1xxyDiTNf8w==",
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "ws": "^8.18.3"
-      },
       "bin": {
         "typescript-compile-process": "bin/typescriptCompileProcess.js"
       },
@@ -4635,16 +4297,6 @@
         "node": ">=8"
       }
     },
-    "node_modules/@sindresorhus/df/node_modules/p-finally": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
-      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
     "node_modules/@sindresorhus/is": {
       "version": "8.1.0",
       "resolved": "https://registry.npmjs.org/@sindresorhus/is/-/is-8.1.0.tgz",
@@ -4846,7 +4498,7 @@
       "version": "24.13.3",
       "resolved": "https://registry.npmjs.org/@types/node/-/node-24.13.3.tgz",
       "integrity": "sha512-Dh8vAsV36ig5wa9OX4pXvMc9D3Veibfw2wix0CUwYODLD8nkj9UsLjASr49nPg+2eKzxhBV+v7L8pXvT4e639Q==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "undici-types": "~7.18.0"
@@ -4889,16 +4541,6 @@
       "integrity": "sha512-I4q9QU9MQv4oEOz4tAHJtNz1cwuLxn2F3xcc2iV5WdqLPpUnj30aUuxt1mAxYTG+oe8CZMV/+6rU4S4gRDzqtQ==",
       "dev": true,
       "license": "MIT"
-    },
-    "node_modules/@types/yauzl": {
-      "version": "2.10.3",
-      "resolved": "https://registry.npmjs.org/@types/yauzl/-/yauzl-2.10.3.tgz",
-      "integrity": "sha512-oJoftv0LSuaDZE3Le4DbKX+KS9G36NzOeSap90UIK0yMA/NhKJhqlSGtNDORNRaIbQfzjXDrQa0ytJ6mNRGz/Q==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "@types/node": "*"
-      }
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.63.0",
@@ -5600,6 +5242,194 @@
         "win32"
       ]
     },
+    "node_modules/@vscode/ripgrep": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep/-/ripgrep-1.18.0.tgz",
+      "integrity": "sha512-ns5lWe44tSfbTMbVUsyB+I1819PVSw4AdpgK0RNkzfWfwy6+3IUNSxwSrfTno1/oWaS/hERNz+XLWVyga2aJBQ==",
+      "license": "MIT",
+      "optional": true,
+      "optionalDependencies": {
+        "@vscode/ripgrep-darwin-arm64": "1.18.0",
+        "@vscode/ripgrep-darwin-x64": "1.18.0",
+        "@vscode/ripgrep-linux-arm": "1.18.0",
+        "@vscode/ripgrep-linux-arm64": "1.18.0",
+        "@vscode/ripgrep-linux-ia32": "1.18.0",
+        "@vscode/ripgrep-linux-ppc64": "1.18.0",
+        "@vscode/ripgrep-linux-riscv64": "1.18.0",
+        "@vscode/ripgrep-linux-s390x": "1.18.0",
+        "@vscode/ripgrep-linux-x64": "1.18.0",
+        "@vscode/ripgrep-win32-arm64": "1.18.0",
+        "@vscode/ripgrep-win32-ia32": "1.18.0",
+        "@vscode/ripgrep-win32-x64": "1.18.0"
+      }
+    },
+    "node_modules/@vscode/ripgrep-darwin-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-arm64/-/ripgrep-darwin-arm64-1.18.0.tgz",
+      "integrity": "sha512-r3ktHSvbFycQNF6sl7sNDPocpsI7J+mEzh1IaZFkY0spm3k2Z9t8hPAeOK7+p0l6p6/swkQC14XWX01low+94Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-darwin-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-darwin-x64/-/ripgrep-darwin-x64-1.18.0.tgz",
+      "integrity": "sha512-25b4gWbL138dGuQU244ebCKKc0q05ULBMoFSz9oAEUHNeqK/lOJViDS7DRvbDazzAzSEdan391Znks/R5mkaTQ==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm/-/ripgrep-linux-arm-1.18.0.tgz",
+      "integrity": "sha512-GDAvufNDHu8zqLEmXstalQF0Wh6wQvdsBi/Vg3Yi3CK4a8XoFXqqXVEHEZ9xQz3t0NfoSEc9JbvK9DDS6FxyxQ==",
+      "cpu": [
+        "arm"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-arm64/-/ripgrep-linux-arm64-1.18.0.tgz",
+      "integrity": "sha512-lQ/5zTG++U0E3IhVgS4EPTTn/U4okncaRMM5GOFfOYZywS4nuD31GhkHbNYlDk5CuDC68+hYJ0/eQeyCKJDA+g==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ia32/-/ripgrep-linux-ia32-1.18.0.tgz",
+      "integrity": "sha512-YWLkSUtFd4Jh5EepIhA9RJSfv3uMAVMo+2rBIGHPBnvgLrZciIs2cDKei1/p6Wc/aCzUoHyMAg2R6tw4ZCBKGg==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-ppc64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-ppc64/-/ripgrep-linux-ppc64-1.18.0.tgz",
+      "integrity": "sha512-quXVY8fwQ8O/lvU1yrSqSl3jlUzysRSb+AfUfCL/tRtphxsKlFvPAejryZ6vg4Bgvn8XL74xb4qMCDmWgYrT5w==",
+      "cpu": [
+        "ppc64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-riscv64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-riscv64/-/ripgrep-linux-riscv64-1.18.0.tgz",
+      "integrity": "sha512-f5kBQBrWfQt8Q7OhSORuNDei5dkYagBj3y4jImSUXGMy8B/Ke7SltSRcUtjPv166FAFfHCAmWuZp3+cWnX2/Vw==",
+      "cpu": [
+        "riscv64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-s390x": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-s390x/-/ripgrep-linux-s390x-1.18.0.tgz",
+      "integrity": "sha512-rTOcJFGGcl2c07RUOWUo4U1ndnemKhY6A9hnMB18uk7jSgJc0d/QLBGWMWpumdtoJtpizn/wIv5mXIisJukusQ==",
+      "cpu": [
+        "s390x"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-linux-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-linux-x64/-/ripgrep-linux-x64-1.18.0.tgz",
+      "integrity": "sha512-mQ3bVrUpnD2vs7QT0vX90Lt0cnUq467uFtEktIdsJJmW296RoSULRGqWgzG1AKxyBpNDD6l4ZO4qKf6SgyC23Q==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-arm64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-arm64/-/ripgrep-win32-arm64-1.18.0.tgz",
+      "integrity": "sha512-vfTIjq1OHnzUjxZcHVQAMbnggp8dpGf+0QKFOZHwWPqFwXxQC8eCWM+5NUdoJ6yrElCeMzoUTXoK/LdZaniB+Q==",
+      "cpu": [
+        "arm64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-ia32": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-ia32/-/ripgrep-win32-ia32-1.18.0.tgz",
+      "integrity": "sha512-//rfAE+BOw5AC2EMmepmiE36jUuevtQYNQqqlw1s3m9FlRxjxEut97RkRPHAu9BG4mSojatZx+kXZXNdyI9caQ==",
+      "cpu": [
+        "ia32"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/ripgrep-win32-x64": {
+      "version": "1.18.0",
+      "resolved": "https://registry.npmjs.org/@vscode/ripgrep-win32-x64/-/ripgrep-win32-x64-1.18.0.tgz",
+      "integrity": "sha512-KNPvtElldqILHdnAetujPaowkNbpqJy3ssIGGN6F6Kve9Qi+nNLI2DN01O83JjCEVQbCzl8Ov3QZ9Eov3BR8Dg==",
+      "cpu": [
+        "x64"
+      ],
+      "license": "MIT",
+      "optional": true,
+      "os": [
+        "win32"
+      ]
+    },
+    "node_modules/@vscode/windows-process-tree": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/@vscode/windows-process-tree/-/windows-process-tree-0.8.0.tgz",
+      "integrity": "sha512-TI+h2GRwX+igD/YYJMQQVAFcsCNSg7Te2yYxQpKMzwto5RsJ8d2KKgOeur/p/6sAOQwZvopiTDOClyTHEn9MhQ==",
+      "hasInstallScript": true,
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "node-addon-api": "7.1.0"
+      }
+    },
     "node_modules/@zkochan/rimraf": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@zkochan/rimraf/-/rimraf-3.0.2.tgz",
@@ -5770,12 +5600,31 @@
         "url": "https://github.com/sponsors/jonschlinkert"
       }
     },
+    "node_modules/argparse": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/argparse/-/argparse-2.0.1.tgz",
+      "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
+      "license": "Python-2.0"
+    },
     "node_modules/array-timsort": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/array-timsort/-/array-timsort-1.0.3.tgz",
       "integrity": "sha512-/+3GRL7dDAGEfM6TseQk/U+mi18TU2Ms9I3UlLdUMhz2hbvGNTKdj9xniwXfUqgYhHxRx0+8UnKkvlNwVU+cWQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/array-union": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
+      "integrity": "sha512-Dxr6QJj/RdU/hCaBjOfxW+q6lyuVE6JFWIrAUpuOOhoJJoQ99cUn3igRaHVB5P9WrgFVN0FfArM3x0cueOU8ng==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "array-uniq": "^1.0.1"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
     },
     "node_modules/array-uniq": {
       "version": "1.0.3",
@@ -6001,9 +5850,9 @@
       }
     },
     "node_modules/bare-url": {
-      "version": "2.4.5",
-      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.5.tgz",
-      "integrity": "sha512-K+y9xF1tN+CdPu4qWwr0QiK1Al07eFPGYK5M2pDXcmHdMdgC/tT/bpmMe1hrmRHaidKLkXrC+cRNYf3XVDUhSQ==",
+      "version": "2.4.6",
+      "resolved": "https://registry.npmjs.org/bare-url/-/bare-url-2.4.6.tgz",
+      "integrity": "sha512-iQxPClE07hETVpbRoX7JXX3v/ZQViCxe/SYCxylRLzdEx1xJAufPptfiOqR8tqiCtmbtMDANKWszzjLu1PMAZQ==",
       "license": "Apache-2.0",
       "optional": true,
       "dependencies": {
@@ -6171,16 +6020,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "node-int64": "^0.4.0"
-      }
-    },
-    "node_modules/buffer-crc32": {
-      "version": "0.2.13",
-      "resolved": "https://registry.npmjs.org/buffer-crc32/-/buffer-crc32-0.2.13.tgz",
-      "integrity": "sha512-VO9Ht/+p3SN7SKWqcrgEzjGbRSJYTx+Q1pTQC0wrWqHx0vpJraQ6GtHx8tvcg1rlK1byhU5gccxgOgj7B0TDkQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/buffer-from": {
@@ -6421,16 +6260,16 @@
       }
     },
     "node_modules/chokidar": {
-      "version": "4.0.3",
-      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-4.0.3.tgz",
-      "integrity": "sha512-Qgzu8kfBvo+cA4962jnP1KkS6Dop5NS6g7R5LFYJr4b8Ub94PPQXUksCw9PvXoeXPRRddRNC5C1JQUR2SMGtnA==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-5.0.0.tgz",
+      "integrity": "sha512-TQMmc3w+5AxjpL8iIiwebF73dRDF4fBIieAqGn9RGCWaEVwQ6Fb2cGe31Yns0RRIzii5goJ1Y7xbMwo1TxMplw==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "readdirp": "^4.0.1"
+        "readdirp": "^5.0.0"
       },
       "engines": {
-        "node": ">= 14.16.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "url": "https://paulmillr.com/funding/"
@@ -6840,7 +6679,7 @@
       "version": "4.4.3",
       "resolved": "https://registry.npmjs.org/debug/-/debug-4.4.3.tgz",
       "integrity": "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT",
       "dependencies": {
         "ms": "^2.1.3"
@@ -6930,6 +6769,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/define-lazy-prop": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/define-lazy-prop/-/define-lazy-prop-3.0.0.tgz",
+      "integrity": "sha512-N+MeXYoqr3pOgn8xfyRPREN7gHakLYjhsHhWGT3fWAiL4IkAt0iDw14QiiEm2bE30c5XX5q0FtAA3CK5f9/BUg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/depd": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/depd/-/depd-2.0.0.tgz",
@@ -6998,6 +6850,42 @@
       "license": "MIT",
       "engines": {
         "node": "^14.15.0 || ^16.10.0 || >=18.0.0"
+      }
+    },
+    "node_modules/dir-glob": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/dir-glob/-/dir-glob-2.2.2.tgz",
+      "integrity": "sha512-f9LBi5QWzIW3I6e//uxZoLBlUt9kcp66qo0sSCxL6YZKc75R1c4MFCoe/LaZiBGmgujvQdxc5Bn3QhfyvK5Hsw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "path-type": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dir-glob/node_modules/path-type": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
+      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "pify": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/dir-glob/node_modules/pify": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
+      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/dunder-proto": {
@@ -7102,6 +6990,18 @@
       },
       "engines": {
         "node": ">=10.13.0"
+      }
+    },
+    "node_modules/entities": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-4.5.0.tgz",
+      "integrity": "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw==",
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
       }
     },
     "node_modules/error-ex": {
@@ -8041,43 +7941,6 @@
         "url": "https://opencollective.com/express"
       }
     },
-    "node_modules/extract-zip": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/extract-zip/-/extract-zip-2.0.1.tgz",
-      "integrity": "sha512-GDhU9ntwuKyGXdZBUgTIe+vXnWj0fppUEtMDL0+idd5Sta8TGpHssn/eusA9mrPr9qNDym6SxAYZjNvCn/9RBg==",
-      "license": "BSD-2-Clause",
-      "optional": true,
-      "dependencies": {
-        "debug": "^4.1.1",
-        "get-stream": "^5.1.0",
-        "yauzl": "^2.10.0"
-      },
-      "bin": {
-        "extract-zip": "cli.js"
-      },
-      "engines": {
-        "node": ">= 10.17.0"
-      },
-      "optionalDependencies": {
-        "@types/yauzl": "^2.9.1"
-      }
-    },
-    "node_modules/extract-zip/node_modules/get-stream": {
-      "version": "5.2.0",
-      "resolved": "https://registry.npmjs.org/get-stream/-/get-stream-5.2.0.tgz",
-      "integrity": "sha512-nBF+F1rAZVCu/p7rjzgA+Yb4lfYXrpl7a6VmJrU8wF9I1CKvP/QwPNZHnOlwbTkY6dvtFIzFMSyQXbLoTQPRpA==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pump": "^3.0.0"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/fast-deep-equal": {
       "version": "3.1.3",
       "resolved": "https://registry.npmjs.org/fast-deep-equal/-/fast-deep-equal-3.1.3.tgz",
@@ -8178,16 +8041,6 @@
       "license": "Apache-2.0",
       "dependencies": {
         "bser": "2.1.1"
-      }
-    },
-    "node_modules/fd-slicer": {
-      "version": "1.1.0",
-      "resolved": "https://registry.npmjs.org/fd-slicer/-/fd-slicer-1.1.0.tgz",
-      "integrity": "sha512-cE1qsB/VwyQozZ+q1dGxR8LBYNZeofhEdUNGSMbQD3Gw2lAzX9Zb3uIU6Ebc/Fmyjo9AWWfnn0AUCHqtevs/8g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "pend": "~1.2.0"
       }
     },
     "node_modules/fdir": {
@@ -8392,9 +8245,9 @@
       }
     },
     "node_modules/fs-extra": {
-      "version": "11.3.6",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.6.tgz",
-      "integrity": "sha512-w8ZNZr2mKIc7qeNaQ9AVPT1+iFaI+Avd4xudVOvdDJ8VytREi1Ft5Ih7hd9jjehod8vAM5GMsfQ/TpPf4EyoEA==",
+      "version": "11.3.0",
+      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
+      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
@@ -8680,6 +8533,63 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/globby": {
+      "version": "14.1.0",
+      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
+      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "@sindresorhus/merge-streams": "^2.1.0",
+        "fast-glob": "^3.3.3",
+        "ignore": "^7.0.3",
+        "path-type": "^6.0.0",
+        "slash": "^5.1.0",
+        "unicorn-magic": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/@sindresorhus/merge-streams": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
+      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/globby/node_modules/ignore": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
+      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">= 4"
+      }
+    },
+    "node_modules/globby/node_modules/slash": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
+      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=14.16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/globrex": {
       "version": "0.1.2",
       "resolved": "https://registry.npmjs.org/globrex/-/globrex-0.1.2.tgz",
@@ -8862,18 +8772,6 @@
         "node": ">=10.19.0"
       }
     },
-    "node_modules/http2-wrapper/node_modules/quick-lru": {
-      "version": "5.1.1",
-      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
-      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
-      "license": "MIT",
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/human-signals": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/human-signals/-/human-signals-2.1.0.tgz",
@@ -9025,6 +8923,22 @@
         "url": "https://github.com/sponsors/ljharb"
       }
     },
+    "node_modules/is-docker": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
+      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
+      "license": "MIT",
+      "optional": true,
+      "bin": {
+        "is-docker": "cli.js"
+      },
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -9117,22 +9031,6 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/is-inside-container/node_modules/is-docker": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/is-docker/-/is-docker-3.0.0.tgz",
-      "integrity": "sha512-eljcgEDlEns/7AXFosB5K/2nCM4P7FQPkGc/DWLy5rmFEWvZayGrik1d9/QIY5nJ4f9YsVvBkA6kJpHn9rISdQ==",
-      "license": "MIT",
-      "optional": true,
-      "bin": {
-        "is-docker": "cli.js"
-      },
-      "engines": {
-        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
     "node_modules/is-module": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-module/-/is-module-1.0.0.tgz",
@@ -9157,6 +9055,19 @@
       "license": "MIT",
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
+      }
+    },
+    "node_modules/is-path-inside": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
+      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/is-plain-obj": {
@@ -9221,6 +9132,22 @@
       "optional": true,
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/is-wsl": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
+      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "is-inside-container": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=16"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
     },
     "node_modules/istanbul-lib-coverage": {
@@ -10753,6 +10680,34 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/lines-and-columns": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/lines-and-columns/-/lines-and-columns-2.0.4.tgz",
+      "integrity": "sha512-wM1+Z03eypVAVUCE7QdSqpVIvelbOakn1M0bPDoA4SGWPx3sNDVUiMo3L6To6WWGClB7VyXnhQ4Sn7gxiJbE6A==",
+      "license": "MIT",
+      "engines": {
+        "node": "^12.20.0 || ^14.13.1 || >=16.0.0"
+      }
+    },
+    "node_modules/linkify-it": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/linkify-it/-/linkify-it-5.0.2.tgz",
+      "integrity": "sha512-ONTm2jCMAVZjgQa/Fy1kScXsuOoF5NPTsoFBdE1KVIZ2vAh/r9+Bqo+0jINCBYnavTPQZz38QzFTme79ENoN3Q==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "uc.micro": "^2.0.0"
+      }
+    },
     "node_modules/locate-path": {
       "version": "6.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-6.0.0.tgz",
@@ -10875,6 +10830,33 @@
       "license": "BSD-3-Clause",
       "dependencies": {
         "tmpl": "1.0.5"
+      }
+    },
+    "node_modules/markdown-it": {
+      "version": "14.3.0",
+      "resolved": "https://registry.npmjs.org/markdown-it/-/markdown-it-14.3.0.tgz",
+      "integrity": "sha512-RCEsPjR+sr0x+AuYp601tKTkgFG4YEPLCzHST3cQ/fhlJkqAkz1L2/Qbp1j9qw5SBwQHFBoW8+hoN5xssOF0Tw==",
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/puzrin"
+        },
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/markdown-it"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "argparse": "^2.0.1",
+        "entities": "^4.5.0",
+        "linkify-it": "^5.0.2",
+        "mdurl": "^2.0.0",
+        "punycode.js": "^2.3.1",
+        "uc.micro": "^2.1.0"
+      },
+      "bin": {
+        "markdown-it": "bin/markdown-it.mjs"
       }
     },
     "node_modules/markdown-table": {
@@ -11169,6 +11151,12 @@
       "integrity": "sha512-U9w+PzSZ00Z5m9rZ5ARVFL5xOfuCHdKYi/1RRwDCJsboFgJDNT3zT6PIPD7mZQYaQLhsZM3GfDRgSMRHhSmVng==",
       "dev": true,
       "license": "CC0-1.0"
+    },
+    "node_modules/mdurl": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/mdurl/-/mdurl-2.1.0.tgz",
+      "integrity": "sha512-1+HBaOx0zi/dQWht8rNv9MYf9qqpqL/kxI0hXImU6Y547zM6Sni8BQibt7ifgMcYtQg41ao3Ivd6cnSM86inpg==",
+      "license": "MIT"
     },
     "node_modules/media-typer": {
       "version": "1.1.0",
@@ -11887,6 +11875,19 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/minimatch": {
+      "version": "3.1.5",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
+      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
+      "devOptional": true,
+      "license": "ISC",
+      "dependencies": {
+        "brace-expansion": "^1.1.7"
+      },
+      "engines": {
+        "node": "*"
+      }
+    },
     "node_modules/minimist": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.8.tgz",
@@ -11938,16 +11939,6 @@
         "node": ">=0.10.0"
       }
     },
-    "node_modules/mount-point/node_modules/pify": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
-      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=0.10.0"
-      }
-    },
     "node_modules/move-file": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/move-file/-/move-file-4.1.0.tgz",
@@ -11965,7 +11956,7 @@
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.1.3.tgz",
       "integrity": "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/napi-postinstall": {
@@ -12009,11 +12000,14 @@
       "license": "MIT"
     },
     "node_modules/node-addon-api": {
-      "version": "7.1.1",
-      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.1.tgz",
-      "integrity": "sha512-5m3bsyrjFWE1xf7nz7YXdN4udnVtXK6/Yfgn5qnahL6bCkf2yKt4k3nuTKAtT4r3IG8JNR2ncsIMdZuAzJjHQQ==",
+      "version": "7.1.0",
+      "resolved": "https://registry.npmjs.org/node-addon-api/-/node-addon-api-7.1.0.tgz",
+      "integrity": "sha512-mNcltoe1R8o7STTegSOHdnJNN7s5EUvhoS7ShnTHDyOSd+8H+UdWODq6qSv67PjC8Zc5JRT8+oLAMCr0SIXw7g==",
       "license": "MIT",
-      "optional": true
+      "optional": true,
+      "engines": {
+        "node": "^16 || ^18 || >= 20"
+      }
     },
     "node_modules/node-int64": {
       "version": "0.4.0",
@@ -12130,6 +12124,27 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/open": {
+      "version": "11.0.0",
+      "resolved": "https://registry.npmjs.org/open/-/open-11.0.0.tgz",
+      "integrity": "sha512-smsWv2LzFjP03xmvFoJ331ss6h+jixfA4UUV/Bsiyuu4YJPfN+FIQGOIiv4w9/+MoHkfkJ22UIaQWRVFRfH6Vw==",
+      "license": "MIT",
+      "optional": true,
+      "dependencies": {
+        "default-browser": "^5.4.0",
+        "define-lazy-prop": "^3.0.0",
+        "is-in-ssh": "^1.0.0",
+        "is-inside-container": "^1.0.0",
+        "powershell-utils": "^0.1.0",
+        "wsl-utils": "^0.3.0"
+      },
+      "engines": {
+        "node": ">=20"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/optionator": {
       "version": "0.9.4",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.9.4.tgz",
@@ -12197,6 +12212,16 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/p-finally": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/p-finally/-/p-finally-2.0.1.tgz",
+      "integrity": "sha512-vpm09aKwq6H9phqRQzecoDpD8TmVyGw70qmWlyq5onxY7tqyTTFVvxMykxQSQKILBSFlbXpypIw2T1Ml7+DDtw==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/p-limit": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-3.1.0.tgz",
@@ -12224,6 +12249,19 @@
       },
       "engines": {
         "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
+    "node_modules/p-map": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.6.tgz",
+      "integrity": "sha512-I4Prw6ivkd6p8PiYR1tXASOAOBzIJwu0TB7fqaX0c/8c3QAehNYmX57EijyGGGBt3c/BIowGwV03RVBtXvHEVg==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=18"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -12441,34 +12479,17 @@
       }
     },
     "node_modules/path-type": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
-      "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
+      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
       "license": "MIT",
       "optional": true,
-      "dependencies": {
-        "pify": "^3.0.0"
+      "engines": {
+        "node": ">=18"
       },
-      "engines": {
-        "node": ">=4"
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
       }
-    },
-    "node_modules/path-type/node_modules/pify": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-      "integrity": "sha512-C3FsVNH1udSEX48gGX1xfvwTWfsYWj5U+8/uK15BGzIGrKoUpghX8hWZwa/OFnakBiiVNmBvemTJR5mcy7iPcg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=4"
-      }
-    },
-    "node_modules/pend": {
-      "version": "1.2.0",
-      "resolved": "https://registry.npmjs.org/pend/-/pend-1.2.0.tgz",
-      "integrity": "sha512-F3asv42UuXchdzt+xXqfW1OGlVBe+mxa2mqI0pg5yAHZPvFmY3Y6drSf/GQ1A86WgWEN9Kzh/WrgKa6iGcHXLg==",
-      "license": "MIT",
-      "optional": true
     },
     "node_modules/picocolors": {
       "version": "1.1.1",
@@ -12487,6 +12508,16 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/jonschlinkert"
+      }
+    },
+    "node_modules/pify": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/pify/-/pify-2.3.0.tgz",
+      "integrity": "sha512-udgsAY+fTnvv7kI7aaxbqwWNb0AHiB0qBO89PZKPkoTmGOgdbrHDKD+0B2X4uTfJ/FT1R09r9gTsjUjNJotuog==",
+      "license": "MIT",
+      "optional": true,
+      "engines": {
+        "node": ">=0.10.0"
       }
     },
     "node_modules/pinkie": {
@@ -12649,9 +12680,9 @@
       }
     },
     "node_modules/powershell-utils": {
-      "version": "0.2.0",
-      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
-      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
       "license": "MIT",
       "optional": true,
       "engines": {
@@ -12737,6 +12768,15 @@
         "node": ">=6"
       }
     },
+    "node_modules/punycode.js": {
+      "version": "2.3.1",
+      "resolved": "https://registry.npmjs.org/punycode.js/-/punycode.js-2.3.1.tgz",
+      "integrity": "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/pure-rand": {
       "version": "7.0.1",
       "resolved": "https://registry.npmjs.org/pure-rand/-/pure-rand-7.0.1.tgz",
@@ -12791,6 +12831,18 @@
       ],
       "license": "MIT",
       "optional": true
+    },
+    "node_modules/quick-lru": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/quick-lru/-/quick-lru-5.1.1.tgz",
+      "integrity": "sha512-WuyALRjWPDGtt/wzJiadO5AXY+8hZ80hVpe6MyivgraREW751X3SbhRvG3eLKOYN+8VEvqLcf3wdnt44Z4S4SA==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
     },
     "node_modules/quote-js-string": {
       "version": "0.1.0",
@@ -12869,13 +12921,13 @@
       "license": "MIT"
     },
     "node_modules/readdirp": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-4.1.2.tgz",
-      "integrity": "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg==",
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-5.0.0.tgz",
+      "integrity": "sha512-9u/XQ1pvrQtYyMpZe7DXKv2p5CNvyVwzUB6uhLAnQwHMSgKMBR62lc7AHljaeteeHXn11XTAaLLUVZYVZyuRBQ==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">= 14.18.0"
+        "node": ">= 20.19.0"
       },
       "funding": {
         "type": "individual",
@@ -12934,21 +12986,6 @@
       },
       "engines": {
         "node": ">=18"
-      }
-    },
-    "node_modules/rename-overwrite/node_modules/fs-extra": {
-      "version": "11.3.0",
-      "resolved": "https://registry.npmjs.org/fs-extra/-/fs-extra-11.3.0.tgz",
-      "integrity": "sha512-Z4XaCL6dUDHfP/jT25jJKMmtxvuwbkrD1vNSMFlo9lNLY2c5FHYSQgHPRZUjAB26TpDEoW9HCOgplrdbaPV/ew==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "graceful-fs": "^4.2.0",
-        "jsonfile": "^6.0.1",
-        "universalify": "^2.0.0"
-      },
-      "engines": {
-        "node": ">=14.14"
       }
     },
     "node_modules/require-directory": {
@@ -13826,7 +13863,7 @@
         "bare-path": "^3.0.0"
       }
     },
-    "node_modules/tar-fs/node_modules/tar-stream": {
+    "node_modules/tar-stream": {
       "version": "3.2.0",
       "resolved": "https://registry.npmjs.org/tar-stream/-/tar-stream-3.2.0.tgz",
       "integrity": "sha512-ojzvCvVaNp6aOTFmG7jaRD0meowIAuPc3cMMhSgKiVWws1GyHbGd/xvnyuRKcKlMpt3qvxx6r0hreCNITP9hIg==",
@@ -13884,19 +13921,6 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/isaacs"
-      }
-    },
-    "node_modules/test-exclude/node_modules/minimatch": {
-      "version": "3.1.5",
-      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.1.5.tgz",
-      "integrity": "sha512-VgjWUsnnT6n+NUk6eZq77zeFdpW2LWDzP6zFGrCbHXiYNul5Dzqk2HHQ5uFH2DNW5Xbp8+jVzaeNt94ssEEl4w==",
-      "dev": true,
-      "license": "ISC",
-      "dependencies": {
-        "brace-expansion": "^1.1.7"
-      },
-      "engines": {
-        "node": "*"
       }
     },
     "node_modules/text-decoder": {
@@ -13999,97 +14023,44 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/trash/node_modules/@sindresorhus/merge-streams": {
-      "version": "2.3.0",
-      "resolved": "https://registry.npmjs.org/@sindresorhus/merge-streams/-/merge-streams-2.3.0.tgz",
-      "integrity": "sha512-LtoMMhxAlorcGhmFYI+LhPgbPZCkgP6ra1YL604EeF6U98pLlQ3iWIGMdWSC+vWmPBWBNgmDBAhnAobLROJmwg==",
+    "node_modules/trash/node_modules/powershell-utils": {
+      "version": "0.2.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.2.0.tgz",
+      "integrity": "sha512-ZlsFlG7MtSFCoc5xreOvBAozCJ6Pf06opgJjh9ONEv418xpZSAzNjstD36C6+JwOnfSqOW/9uDkqKjezTdxZhw==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/trash/node_modules/globby": {
-      "version": "14.1.0",
-      "resolved": "https://registry.npmjs.org/globby/-/globby-14.1.0.tgz",
-      "integrity": "sha512-0Ia46fDOaT7k4og1PDW4YbodWWr3scS2vAr2lTbsplOt2WkKp0vQbkI9wKis/T5LV/dqPjO3bpS/z6GTJB82LA==",
+    "node_modules/trash/node_modules/wsl-utils": {
+      "version": "0.4.0",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.4.0.tgz",
+      "integrity": "sha512-9YmF+2sFEd+T7TkwlmE337F0IVzfDvDknhtpBQxxXzEOfgPphGlFYpyx0cTuCIFj8/p+sqwBYAeGxOMNSzPPDA==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
-        "@sindresorhus/merge-streams": "^2.1.0",
-        "fast-glob": "^3.3.3",
-        "ignore": "^7.0.3",
-        "path-type": "^6.0.0",
-        "slash": "^5.1.0",
-        "unicorn-magic": "^0.3.0"
+        "is-wsl": "^3.1.0",
+        "powershell-utils": "^0.1.0"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
-    "node_modules/trash/node_modules/ignore": {
-      "version": "7.0.6",
-      "resolved": "https://registry.npmjs.org/ignore/-/ignore-7.0.6.tgz",
-      "integrity": "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw==",
+    "node_modules/trash/node_modules/wsl-utils/node_modules/powershell-utils": {
+      "version": "0.1.0",
+      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
+      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
       "license": "MIT",
       "optional": true,
       "engines": {
-        "node": ">= 4"
-      }
-    },
-    "node_modules/trash/node_modules/is-path-inside": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-4.0.0.tgz",
-      "integrity": "sha512-lJJV/5dYS+RcL8uQdBDW9c9uWFLLBNRyFhnAKXw5tVqLlKZ4RMGZKv+YQ/IA3OhD+RpbJa1LLFM1FQPGyIXvOA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=12"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/trash/node_modules/p-map": {
-      "version": "7.0.5",
-      "resolved": "https://registry.npmjs.org/p-map/-/p-map-7.0.5.tgz",
-      "integrity": "sha512-e8vJF4XdVkzqqSHguEMz41mQO1wKwxKm5ENrUJQUu9kLDCtn83cxbyHZcszr4QC5zEA7WffRRC4gsTecC7J9oA==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/trash/node_modules/path-type": {
-      "version": "6.0.0",
-      "resolved": "https://registry.npmjs.org/path-type/-/path-type-6.0.0.tgz",
-      "integrity": "sha512-Vj7sf++t5pBD637NSfkxpHSMfWaeig5+DKWLhcqIYx6mWQz5hdJTGDVMQiJcw1ZYkhs7AazKDGpRVji1LJCZUQ==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=18"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/trash/node_modules/slash": {
-      "version": "5.1.0",
-      "resolved": "https://registry.npmjs.org/slash/-/slash-5.1.0.tgz",
-      "integrity": "sha512-ZA6oR3T/pEyuqwMgAKT0/hAv8oAXckzbkmR0UkUosQ+Mc4RxGoJkRmwHgHufaenlyAgE1Mxgpdcrf75y6XcnDg==",
-      "license": "MIT",
-      "optional": true,
-      "engines": {
-        "node": ">=14.16"
+        "node": ">=20"
       },
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
@@ -14316,6 +14287,12 @@
         "typescript": ">=4.8.4 <6.1.0"
       }
     },
+    "node_modules/uc.micro": {
+      "version": "2.1.0",
+      "resolved": "https://registry.npmjs.org/uc.micro/-/uc.micro-2.1.0.tgz",
+      "integrity": "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A==",
+      "license": "MIT"
+    },
     "node_modules/uglify-js": {
       "version": "3.19.3",
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-3.19.3.tgz",
@@ -14346,7 +14323,7 @@
       "version": "7.18.2",
       "resolved": "https://registry.npmjs.org/undici-types/-/undici-types-7.18.2.tgz",
       "integrity": "sha512-AsuCzffGHJybSaRrmr5eHr81mwJU3kjw6M+uprWvCXiNeN9SOGwQ3Jn8jb8m3Z6izVgknn1R0FTCEAP2QrLY/w==",
-      "devOptional": true,
+      "dev": true,
       "license": "MIT"
     },
     "node_modules/unicorn-magic": {
@@ -14731,44 +14708,15 @@
       }
     },
     "node_modules/wsl-utils": {
-      "version": "0.4.0",
-      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.4.0.tgz",
-      "integrity": "sha512-9YmF+2sFEd+T7TkwlmE337F0IVzfDvDknhtpBQxxXzEOfgPphGlFYpyx0cTuCIFj8/p+sqwBYAeGxOMNSzPPDA==",
+      "version": "0.3.1",
+      "resolved": "https://registry.npmjs.org/wsl-utils/-/wsl-utils-0.3.1.tgz",
+      "integrity": "sha512-g/eziiSUNBSsdDJtCLB8bdYEUMj4jR7AGeUo96p/3dTafgjHhpF4RiCFPiRILwjQoDXx5MqkBr4fwWtR3Ky4Wg==",
       "license": "MIT",
       "optional": true,
       "dependencies": {
         "is-wsl": "^3.1.0",
         "powershell-utils": "^0.1.0"
       },
-      "engines": {
-        "node": ">=20"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/wsl-utils/node_modules/is-wsl": {
-      "version": "3.1.1",
-      "resolved": "https://registry.npmjs.org/is-wsl/-/is-wsl-3.1.1.tgz",
-      "integrity": "sha512-e6rvdUCiQCAuumZslxRJWR/Doq4VpPR82kqclvcS0efgt430SlGIk05vdCN58+VrzgtIcfNODjozVielycD4Sw==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "is-inside-container": "^1.0.0"
-      },
-      "engines": {
-        "node": ">=16"
-      },
-      "funding": {
-        "url": "https://github.com/sponsors/sindresorhus"
-      }
-    },
-    "node_modules/wsl-utils/node_modules/powershell-utils": {
-      "version": "0.1.0",
-      "resolved": "https://registry.npmjs.org/powershell-utils/-/powershell-utils-0.1.0.tgz",
-      "integrity": "sha512-dM0jVuXJPsDN6DvRpea484tCUaMiXWjuCn++HGTqUWzGDjv5tZkEZldAJ/UMlqRYGFrD/etByo4/xOuC/snX2A==",
-      "license": "MIT",
-      "optional": true,
       "engines": {
         "node": ">=20"
       },
@@ -14886,17 +14834,6 @@
         "node": ">=12"
       }
     },
-    "node_modules/yauzl": {
-      "version": "2.10.0",
-      "resolved": "https://registry.npmjs.org/yauzl/-/yauzl-2.10.0.tgz",
-      "integrity": "sha512-p4a9I6X6nu6IhoGmBqAcbJy1mlC4j27vEPZX9F4L4/vZT3Lyq1VkFHw/V/PUcB9Buo+DG3iHkT0x3Qya58zc3g==",
-      "license": "MIT",
-      "optional": true,
-      "dependencies": {
-        "buffer-crc32": "~0.2.3",
-        "fd-slicer": "~1.1.0"
-      }
-    },
     "node_modules/yocto-queue": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/yocto-queue/-/yocto-queue-0.1.0.tgz",
@@ -14970,13 +14907,6 @@
         "ts-jest": "^29.4.11"
       }
     },
-    "packages/keybindings-view/node_modules/@lvce-editor/constants": {
-      "version": "5.16.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/constants/-/constants-5.16.0.tgz",
-      "integrity": "sha512-U+3Tk9caHOdjrO/heceh6vCDvgwsaCYG826PY4TLyKrZ1S5oqvbJYgwdU5jLovxGhYFdA9/ZEQk93cEXFABqCg==",
-      "dev": true,
-      "license": "MIT"
-    },
     "packages/keybindings-view/node_modules/@lvce-editor/fuzzy-search": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/@lvce-editor/fuzzy-search/-/fuzzy-search-2.0.1.tgz",
@@ -14990,46 +14920,6 @@
       "integrity": "sha512-LRtTevG7feHoUhaajgey8SlHRawFSAPS3SxM6n/QADEFaQFzQiTWYK5gOOq7oKp1MPIn1t/UXfFtGycACzvNeA==",
       "dev": true,
       "license": "MIT"
-    },
-    "packages/keybindings-view/node_modules/@lvce-editor/ipc": {
-      "version": "15.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/ipc/-/ipc-15.0.0.tgz",
-      "integrity": "sha512-PY8HVhuShfGaTgTSgrsgwgv7Po3WPkgh9AlilgYull4yFPKYZphlGogMSudxq+IsdhKYjD7hdncUEoox+idXiQ==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/verror": "^1.7.0",
-        "@lvce-editor/web-socket-server": "^2.1.0"
-      },
-      "engines": {
-        "node": ">=22"
-      }
-    },
-    "packages/keybindings-view/node_modules/@lvce-editor/rpc": {
-      "version": "6.4.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc/-/rpc-6.4.0.tgz",
-      "integrity": "sha512-AhIyFrPz9/9usLNSLNdMtHxSmrfYw4TfJXRMV19px/eYOv+Y20pEq3O31HtKejZaUVRUbPhhJ0EOa0z9YsGAcA==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/command": "^2.0.0",
-        "@lvce-editor/ipc": "^15.0.0",
-        "@lvce-editor/json-rpc": "^8.0.0"
-      }
-    },
-    "packages/keybindings-view/node_modules/@lvce-editor/rpc-registry": {
-      "version": "9.31.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/rpc-registry/-/rpc-registry-9.31.0.tgz",
-      "integrity": "sha512-GaQ1UPuT6NV2NvtqhAAy+RlktAh4buYyegdRroJigVM91q6vEmvcMPw1k2Xs6/v30EATXJkp/RQ7lVMjm7CPog==",
-      "dev": true,
-      "license": "MIT",
-      "dependencies": {
-        "@lvce-editor/assert": "^1.5.1",
-        "@lvce-editor/constants": "^5.16.0",
-        "@lvce-editor/rpc": "^6.4.0"
-      }
     },
     "packages/memory": {
       "name": "@lvce-editor/text-search-worker-memory",
@@ -15117,7 +15007,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "0.78.0"
+        "@lvce-editor/server": "0.94.6"
       }
     }
   }

--- a/packages/e2e/src/keybindings.add-and-remove-keybinding.ts
+++ b/packages/e2e/src/keybindings.add-and-remove-keybinding.ts
@@ -1,0 +1,48 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.add-and-remove-keybinding'
+
+export const test: Test = async ({ Command, expect, KeyBindingsEditor, Locator }) => {
+  // arrange
+  await KeyBindingsEditor.open()
+  await KeyBindingsEditor.handleInput('About.handleClickClose')
+  await KeyBindingsEditor.focusFirst()
+
+  // act
+  await KeyBindingsEditor.addKeyBinding()
+  const defineKeyBindingWidget = Locator('.Viewlet.DefineKeyBinding')
+  await expect(defineKeyBindingWidget).toBeVisible()
+  const defineKeyBindingInput = defineKeyBindingWidget.locator('input')
+  const viewletStates = await Command.execute('Viewlet.getAllStates')
+  const defineKeyBindingState = Object.values(viewletStates).find(
+    (candidate: any) => candidate.message === 'Press Desired Key Combination, Then Press Enter',
+  )
+  if (!defineKeyBindingState) {
+    throw new Error('Define keybinding state not found')
+  }
+  const defineKeyBindingUid = (defineKeyBindingState as { uid: number }).uid
+  await Command.execute('Viewlet.executeViewletCommand', defineKeyBindingUid, 'handleKeyDown', '9', true, true, false, false)
+  await expect(defineKeyBindingInput).toHaveValue('Ctrl+Alt+9')
+  await Command.execute('Viewlet.executeViewletCommand', defineKeyBindingUid, 'handleKeyDown', 'Enter', false, false, false, false)
+
+  // assert
+  await expect(defineKeyBindingWidget).toBeHidden()
+  const rows = Locator('.TableBody .TableRow')
+  await expect(rows).toHaveCount(2)
+  const userKeyBindingCell = Locator('.TableBody .TableRow:nth-of-type(2) .TableCell:nth-of-type(3)')
+  const userSourceCell = Locator('.TableBody .TableRow:nth-of-type(2) .TableCell:nth-of-type(5)')
+  await expect(userKeyBindingCell).toHaveText('Ctrl+Alt+9')
+  await expect(userSourceCell).toHaveText('User')
+
+  // act
+  await KeyBindingsEditor.focusLast()
+  await KeyBindingsEditor.removeKeyBinding()
+
+  // assert
+  await expect(rows).toHaveCount(1)
+  const remainingRow = rows.nth(0)
+  const remainingKeyBindingCell = remainingRow.locator('.TableCell').nth(2)
+  const remainingSourceCell = remainingRow.locator('.TableCell').nth(4)
+  await expect(remainingKeyBindingCell).toHaveText('Escape')
+  await expect(remainingSourceCell).toHaveText('System')
+}

--- a/packages/e2e/src/keybindings.change-keybinding.ts
+++ b/packages/e2e/src/keybindings.change-keybinding.ts
@@ -1,0 +1,36 @@
+import type { Test } from '@lvce-editor/test-with-playwright'
+
+export const name = 'keybindings.change-keybinding'
+
+export const test: Test = async ({ Command, expect, KeyBindingsEditor, Locator }) => {
+  // arrange
+  await KeyBindingsEditor.open()
+  await KeyBindingsEditor.handleInput('About.handleClickClose')
+  await KeyBindingsEditor.focusFirst()
+
+  // act
+  await KeyBindingsEditor.handleDoubleClick(70, 145)
+  const defineKeyBindingWidget = Locator('.Viewlet.DefineKeyBinding')
+  await expect(defineKeyBindingWidget).toBeVisible()
+  const defineKeyBindingInput = defineKeyBindingWidget.locator('input')
+  const viewletStates = await Command.execute('Viewlet.getAllStates')
+  const defineKeyBindingState = Object.values(viewletStates).find(
+    (candidate: any) => candidate.message === 'Press Desired Key Combination, Then Press Enter',
+  )
+  if (!defineKeyBindingState) {
+    throw new Error('Define keybinding state not found')
+  }
+  const defineKeyBindingUid = (defineKeyBindingState as { uid: number }).uid
+  await Command.execute('Viewlet.executeViewletCommand', defineKeyBindingUid, 'handleKeyDown', '9', true, true, false, false)
+  await expect(defineKeyBindingInput).toHaveValue('Ctrl+Alt+9')
+  await Command.execute('Viewlet.executeViewletCommand', defineKeyBindingUid, 'handleKeyDown', 'Enter', false, false, false, false)
+
+  // assert
+  await expect(defineKeyBindingWidget).toBeHidden()
+  const rows = Locator('.TableBody .TableRow')
+  await expect(rows).toHaveCount(1)
+  const changedKeyBindingCell = Locator('.TableBody .TableRow:nth-of-type(1) .TableCell:nth-of-type(3)')
+  const changedSourceCell = Locator('.TableBody .TableRow:nth-of-type(1) .TableCell:nth-of-type(5)')
+  await expect(changedKeyBindingCell).toHaveText('Ctrl+Alt+9')
+  await expect(changedSourceCell).toHaveText('User')
+}

--- a/packages/e2e/src/keybindings.filter.ts
+++ b/packages/e2e/src/keybindings.filter.ts
@@ -16,10 +16,8 @@ export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
   // assert
   const rows = Locator('.TableBody .TableRow')
   await expect(rows).toHaveCount(2)
-  const firstRow = Locator('.TableBody .TableRow').nth(0)
-  const firstCell = firstRow.locator('.TableCell').nth(1)
+  const firstCell = Locator('.TableBody .TableRow:nth-of-type(1) .TableCell:nth-of-type(2)')
   await expect(firstCell).toHaveText('About.focusNext')
-  const secondRow = Locator('.TableBody .TableRow').nth(1)
-  const secondCell = secondRow.locator('.TableCell').nth(1)
+  const secondCell = Locator('.TableBody .TableRow:nth-of-type(2) .TableCell:nth-of-type(2)')
   await expect(secondCell).toHaveText('About.focusPrevious')
 }

--- a/packages/e2e/src/keybindings.filtered-command-column.ts
+++ b/packages/e2e/src/keybindings.filtered-command-column.ts
@@ -6,6 +6,6 @@ export const test: Test = async (api) => {
   await api.KeyBindingsEditor.open()
   await api.KeyBindingsEditor.handleInput('About.focus')
 
-  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(1)).toHaveText('About.focusNext')
-  await api.expect(api.Locator('.TableBody .TableRow').nth(1).locator('.TableCell').nth(1)).toHaveText('About.focusPrevious')
+  await api.expect(api.Locator('.TableBody .TableRow:nth-of-type(1) .TableCell:nth-of-type(2)')).toHaveText('About.focusNext')
+  await api.expect(api.Locator('.TableBody .TableRow:nth-of-type(2) .TableCell:nth-of-type(2)')).toHaveText('About.focusPrevious')
 }

--- a/packages/e2e/src/keybindings.filtered-keybinding-column.ts
+++ b/packages/e2e/src/keybindings.filtered-keybinding-column.ts
@@ -6,6 +6,6 @@ export const test: Test = async (api) => {
   await api.KeyBindingsEditor.open()
   await api.KeyBindingsEditor.handleInput('About.focus')
 
-  await api.expect(api.Locator('.TableBody .TableRow').nth(0).locator('.TableCell').nth(2)).toHaveText('Tab')
-  await api.expect(api.Locator('.TableBody .TableRow').nth(1).locator('.TableCell').nth(2)).toHaveText('Shift+Tab')
+  await api.expect(api.Locator('.TableBody .TableRow:nth-of-type(1) .TableCell:nth-of-type(3)')).toHaveText('Tab')
+  await api.expect(api.Locator('.TableBody .TableRow:nth-of-type(2) .TableCell:nth-of-type(3)')).toHaveText('Shift+Tab')
 }

--- a/packages/e2e/src/keybindings.show-same-keybindings.ts
+++ b/packages/e2e/src/keybindings.show-same-keybindings.ts
@@ -2,8 +2,6 @@ import type { Test } from '@lvce-editor/test-with-playwright'
 
 export const name = 'keybindings.show-same-keybindings'
 
-export const skip = 1
-
 export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
   // arrange
   await KeyBindingsEditor.open()
@@ -20,6 +18,9 @@ export const test: Test = async ({ expect, KeyBindingsEditor, Locator }) => {
   await KeyBindingsEditor.showSameKeyBindings()
 
   // assert
-  // const focusNextRow = Locator('.TableCell', { hasText: 'Main.focusNext' })
-  // await expect(focusNextRow).toBeVisible()
+  await expect(input).toHaveValue('"Tab"')
+  const aboutFocusNextCell = Locator('.TableCell', { hasText: 'About.focusNext' })
+  const mainFocusNextCell = Locator('.TableCell', { hasText: 'Main.focusNext' })
+  await expect(aboutFocusNextCell).toBeVisible()
+  await expect(mainFocusNextCell).toBeVisible()
 }

--- a/packages/keybindings-view/src/parts/AddKeyBinding/AddKeyBinding.ts
+++ b/packages/keybindings-view/src/parts/AddKeyBinding/AddKeyBinding.ts
@@ -13,6 +13,6 @@ export const addKeyBinding = async (state: KeyBindingsState): Promise<KeyBinding
     defineKeyBindingsId: DefineKeyBindingMode.Add,
   }
   KeyBindingsStates.set(uid, newState, newState)
-  await ShowDefineKeyBinding.showDefineKeyBinding()
+  await ShowDefineKeyBinding.showDefineKeyBinding(uid)
   return state
 }

--- a/packages/keybindings-view/src/parts/ChangeKeyBinding/ChangeKeyBinding.ts
+++ b/packages/keybindings-view/src/parts/ChangeKeyBinding/ChangeKeyBinding.ts
@@ -13,6 +13,6 @@ export const changeKeyBinding = async (state: KeyBindingsState): Promise<KeyBind
     defineKeyBindingsId: DefineKeyBindingMode.Change,
   }
   KeyBindingsStates.set(uid, newState, newState)
-  await ShowDefineKeyBinding.showDefineKeyBinding()
+  await ShowDefineKeyBinding.showDefineKeyBinding(uid)
   return state
 }

--- a/packages/keybindings-view/src/parts/HandleClickIndex/HandleClickIndex.ts
+++ b/packages/keybindings-view/src/parts/HandleClickIndex/HandleClickIndex.ts
@@ -18,7 +18,7 @@ export const handleClickIndex = async (state: KeyBindingsState, index: number, s
       defineKeyBindingsId: DefineKeyBindingMode.Change,
     }
     KeyBindingsStates.set(uid, defineState, defineState)
-    await ShowDefineKeyBinding.showDefineKeyBinding()
+    await ShowDefineKeyBinding.showDefineKeyBinding(uid)
     return state
   }
   return newState

--- a/packages/keybindings-view/src/parts/ShowDefineKeyBinding/ShowDefineKeyBinding.ts
+++ b/packages/keybindings-view/src/parts/ShowDefineKeyBinding/ShowDefineKeyBinding.ts
@@ -1,6 +1,6 @@
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as ViewletModuleId from '../ViewletModuleId/ViewletModuleId.ts'
 
-export const showDefineKeyBinding = async (): Promise<void> => {
-  await RendererWorker.openWidget(ViewletModuleId.DefineKeyBinding)
+export const showDefineKeyBinding = async (parentUid: number): Promise<void> => {
+  await RendererWorker.invoke('Viewlet.openWidget', ViewletModuleId.DefineKeyBinding, parentUid)
 }

--- a/packages/keybindings-view/test/AddKeyBinding.test.ts
+++ b/packages/keybindings-view/test/AddKeyBinding.test.ts
@@ -19,7 +19,7 @@ test('addKeyBinding - opens the keybinding widget and records add mode', async (
 
   const result = await AddKeyBinding.addKeyBinding(state)
 
-  expect(mockRpc.invocations).toEqual([['Viewlet.openWidget', 'DefineKeyBinding']])
+  expect(mockRpc.invocations).toEqual([['Viewlet.openWidget', 'DefineKeyBinding', 1]])
   expect(result).toBe(state)
   expect(KeyBindingsStates.get(state.uid).newState.defineKeyBindingsId).toBe(DefineKeyBindingMode.Add)
 })

--- a/packages/keybindings-view/test/HandleClick.test.ts
+++ b/packages/keybindings-view/test/HandleClick.test.ts
@@ -23,7 +23,7 @@ test.skip('handleClick - edit icon path triggers openWidget', async () => {
   const eventX = 15 // Inside edit icon area (padding < x < padding+size)
   const eventY = 0
   const newState = await HandleClick.handleClick(state, eventX, eventY)
-  expect(mockRpc.invocations).toEqual([['Viewlet.openWidget', 'DefineKeyBinding']])
+  expect(mockRpc.invocations).toEqual([['Viewlet.openWidget', 'DefineKeyBinding', 1]])
   expect(newState.focus).toBe(WhenExpression.FocusKeyBindingsTable)
 })
 

--- a/packages/keybindings-view/test/HandleDoubleClick.test.ts
+++ b/packages/keybindings-view/test/HandleDoubleClick.test.ts
@@ -20,7 +20,7 @@ test('handleDoubleClick - sets selection and opens widget', async () => {
     y: 0,
   }
   const result = await HandleDoubleClick.handleDoubleClick(state, 0, 15)
-  expect(mockRpc.invocations).toEqual([['Viewlet.openWidget', 'DefineKeyBinding']])
+  expect(mockRpc.invocations).toEqual([['Viewlet.openWidget', 'DefineKeyBinding', 1]])
   expect(result.selectedIndex).toBeGreaterThanOrEqual(-1)
   // expect(result.defineKeyBindingsId).toBe(1)
 })

--- a/packages/keybindings-view/test/ShowDefineKeyBinding.test.ts
+++ b/packages/keybindings-view/test/ShowDefineKeyBinding.test.ts
@@ -6,8 +6,8 @@ test('showDefineKeyBinding', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'Viewlet.openWidget'() {},
   })
-  await ShowDefineKeyBinding.showDefineKeyBinding()
-  expect(mockRpc.invocations).toEqual([['Viewlet.openWidget', 'DefineKeyBinding']])
+  await ShowDefineKeyBinding.showDefineKeyBinding(7)
+  expect(mockRpc.invocations).toEqual([['Viewlet.openWidget', 'DefineKeyBinding', 7]])
 })
 
 test('showDefineKeyBinding - error handling', async () => {
@@ -16,5 +16,5 @@ test('showDefineKeyBinding - error handling', async () => {
       throw new Error('Failed to show define key binding')
     },
   })
-  await expect(ShowDefineKeyBinding.showDefineKeyBinding()).rejects.toThrow('Failed to show define key binding')
+  await expect(ShowDefineKeyBinding.showDefineKeyBinding(7)).rejects.toThrow('Failed to show define key binding')
 })

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,6 +11,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "0.78.0"
+    "@lvce-editor/server": "0.94.6"
   }
 }


### PR DESCRIPTION
## Summary

- pass the keybindings view runtime UID through the define-keybinding widget handoff
- update the embedded server to `@lvce-editor/server` 0.94.6, which completes the UID-aware awaited dialog disposal path
- add browser coverage for add/remove, change, and show-same-keybindings
- repair filtering assertions so the full suite targets the intended table rows
- record the resolved cross-repository root cause in the exploratory issue report

## Verification

- `npm test` — 293 passed, 16 skipped
- `npm run type-check`
- `npm run lint` — 0 errors, 16 pre-existing skipped-test warnings
- `npm run measure --workspace=packages/memory`
- `npx test-with-playwright --only-extension=. --test-path=. --headless --reuse-page` — 64 passed, 6 skipped, 0 failed
