### PR TITLE
fix: support keybinding persistence on Windows

### DIFF
--- a/keybindings-view-issues/README.md
+++ b/keybindings-view-issues/README.md
@@ -26,20 +26,23 @@
 | Severity  | Count |
 | --------- | ----- |
 | Critical  | 0     |
-| High      | 3     |
+| High      | 4     |
 | Medium    | 3     |
 | Low       | 1     |
-| **Total** | **7** |
+| **Total** | **8** |
 
-| Issue                                                                                  | Fix status         |
-| -------------------------------------------------------------------------------------- | ------------------ |
-| [Record Keys drops shortcut modifiers](record-keys-drops-modifiers/README.md)          | Fixed and verified |
-| [Filter drops characters during fast typing](filter-drops-fast-input/README.md)        | Fixed and verified |
-| [Source column is never visible](source-column-not-visible/README.md)                  | Fixed and verified |
-| [Keybinding mutations do not apply](keybinding-mutations-do-not-apply/README.md)       | Fixed and verified |
-| [Keybinding mutations do not persist](keybinding-mutations-do-not-persist/README.md)   | Fixed locally      |
-| [Reset Keybinding does not restore defaults](reset-keybinding-does-not-work/README.md) | Fixed locally      |
-| [No-results filter has no empty-state message](no-results-has-no-message/README.md)    | Fixed and verified |
+| Issue                                                                                     | Fix status         |
+| ----------------------------------------------------------------------------------------- | ------------------ |
+| [Record Keys drops shortcut modifiers](record-keys-drops-modifiers/README.md)             | Fixed and verified |
+| [Filter drops characters during fast typing](filter-drops-fast-input/README.md)           | Fixed and verified |
+| [Source column is never visible](source-column-not-visible/README.md)                     | Fixed and verified |
+| [Keybinding mutations do not apply](keybinding-mutations-do-not-apply/README.md)          | Fixed and verified |
+| [Keybinding mutations do not persist](keybinding-mutations-do-not-persist/README.md)      | Fixed locally      |
+| [Reset Keybinding does not restore defaults](reset-keybinding-does-not-work/README.md)    | Fixed locally      |
+| [Keybinding persistence fails on Windows](windows-keybinding-persistence-fails/README.md) | Open               |
+| [No-results filter has no empty-state message](no-results-has-no-message/README.md)       | Fixed and verified |
 
-The final combined build uses `@lvce-editor/server` 0.94.6. Its full browser
-suite passed with 64 tests passing, 6 intentionally skipped, and no failures.
+The persistence implementation's combined build uses `@lvce-editor/server`
+0.94.6. Its full browser suite passed with 64 tests passing, 6 intentionally
+skipped, and no failures on Linux. The Windows compatibility follow-up is
+pending verification with `@lvce-editor/server` 0.94.7.

--- a/keybindings-view-issues/windows-keybinding-persistence-fails/README.md
+++ b/keybindings-view-issues/windows-keybinding-persistence-fails/README.md
@@ -1,0 +1,55 @@
+# Keybinding persistence fails on Windows
+
+| Field    | Value                                           |
+| -------- | ----------------------------------------------- |
+| Severity | High                                            |
+| Category | Functional / platform compatibility             |
+| URL      | https://lvce-editor.github.io/keybindings-view/ |
+
+## Description
+
+Adding or changing a keybinding fails on Windows when the user configuration
+directory does not already exist. The capture dialog cannot complete because
+the app-filesystem fallback attempts to create the invalid directory
+`file://`.
+
+Expected: `app://keybindings.json` creates its parent configuration directory
+and persists the mutation on Windows just as it does on Linux and macOS.
+
+Actual: the mutation rejects with:
+
+```text
+Failed to write C:\Users\runneradmin\.config\lvce-oss\keybindings.json:
+Failed to create directory "file://":
+TypeError [ERR_INVALID_FILE_URL_PATH]: File URL path must be absolute
+```
+
+## Reproduction
+
+1. Start the keybindings-view combined build on Windows with no existing
+   `lvce-oss` configuration directory.
+2. Open **Keyboard Shortcuts**.
+3. Add or change a keybinding and submit the capture dialog.
+4. Observe that the dialog disposal fails and the mutation is not applied.
+
+The issue was reproduced by both mutation browser tests in the Windows PR
+workflow for the persistence implementation. The same build passed on Ubuntu
+and macOS.
+
+## Root cause
+
+The shared app-filesystem fallback derives a parent directory with the
+workspace URI helper. On Windows, that helper uses the wrong separator for the
+native configuration path and truncates it to `file://`.
+
+## Resolution
+
+The host now derives native parent directories with a separator-aware helper
+that supports POSIX and Windows paths while preserving URI handling. The fix
+landed in
+[lvce-editor#13083](https://github.com/lvce-editor/lvce-editor/pull/13083)
+and is included in `@lvce-editor/server` 0.94.7.
+
+The host's unit, integration, and full CI suites passed on Windows x64 and
+Windows arm64. This report remains open until keybindings-view's mutation
+browser tests also pass on Windows with server 0.94.7.

--- a/package-lock.json
+++ b/package-lock.json
@@ -3046,9 +3046,9 @@
       "license": "MIT"
     },
     "node_modules/@lvce-editor/extension-host-helper-process": {
-      "version": "0.94.6",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.94.6.tgz",
-      "integrity": "sha512-h1iqsQz9XZFl5pF/NbQow7iL44fN+0kCQP0CfPyQ89IWPzdQaFwJN1/clwQqKr+qNFWrD8Ss9fg37vnu6P8zsw==",
+      "version": "0.94.7",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/extension-host-helper-process/-/extension-host-helper-process-0.94.7.tgz",
+      "integrity": "sha512-yMfWKfHdxfT40lcx3owv+h0zB6dAEFUMTkYN4kLP3DFVohHNx1ShgzGKDbP4aaYX1TkWj/EO0gSsPj4fmMEp2w==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "^1.7.0",
@@ -3504,13 +3504,13 @@
       }
     },
     "node_modules/@lvce-editor/server": {
-      "version": "0.94.6",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.94.6.tgz",
-      "integrity": "sha512-umEEKyQuYp43ydVnsbJJRjDN3amx9Sa6P5pMNjx3g4E1wzrP6fk4nKUDvCjR4z8NKKWH3NVJ+iC/MjSHpdydFA==",
+      "version": "0.94.7",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/server/-/server-0.94.7.tgz",
+      "integrity": "sha512-Jnk5/UCwMfsLAwKlSBDegSnkQkIABCJCR+ZzIZLEOvfdcac7tWXxZJI4EWgSGl9ihjGjG8V4mu67j8L0NjZwMQ==",
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/shared-process": "0.94.6",
-        "@lvce-editor/static-server": "0.94.6"
+        "@lvce-editor/shared-process": "0.94.7",
+        "@lvce-editor/static-server": "0.94.7"
       },
       "bin": {
         "server": "bin/server.js"
@@ -3520,14 +3520,14 @@
       }
     },
     "node_modules/@lvce-editor/shared-process": {
-      "version": "0.94.6",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.94.6.tgz",
-      "integrity": "sha512-1f7px4YLb/4QCV2c67nunMkyX7WO+HcBHzO+ZwN52r8TspeIBOoKsb0ZftgL0wcNyxcGzhTNuSrsTU8eLLsyBg==",
+      "version": "0.94.7",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/shared-process/-/shared-process-0.94.7.tgz",
+      "integrity": "sha512-HnhZDcm97j8+dAlNfIFAP9+R4aWJSsXR/yCGoYljmobjBGANUn2kvn3Ms81QSBf/jQ8S0uO6lYHaDyI4+XnU7g==",
       "license": "MIT",
       "dependencies": {
         "@lvce-editor/assert": "1.7.0",
         "@lvce-editor/auth-process": "1.12.0",
-        "@lvce-editor/extension-host-helper-process": "0.94.6",
+        "@lvce-editor/extension-host-helper-process": "0.94.7",
         "@lvce-editor/ipc": "16.6.0",
         "@lvce-editor/json-rpc": "8.5.0",
         "@lvce-editor/jsonc-parser": "1.5.0",
@@ -3559,9 +3559,9 @@
       }
     },
     "node_modules/@lvce-editor/static-server": {
-      "version": "0.94.6",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.94.6.tgz",
-      "integrity": "sha512-AlTdD8PhtASGL7j6oNH4I80/3cGdRFj6o+q396/qGYouCatUHiiGkB/yypE0aKHMwCAwmb5kD7c7h2WeUf7WdA==",
+      "version": "0.94.7",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/static-server/-/static-server-0.94.7.tgz",
+      "integrity": "sha512-GshP+8h58Gnb2zjFSdkJJn7JE7+5Htm1eWytVGclV+4v9vO1hQZJUeCn68t/55wb5Td++H8raFgePUMpK05Pvw==",
       "license": "MIT",
       "engines": {
         "node": ">=24"
@@ -15007,7 +15007,7 @@
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {
-        "@lvce-editor/server": "0.94.6"
+        "@lvce-editor/server": "0.94.7"
       }
     }
   }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -11,6 +11,6 @@
   "author": "",
   "license": "MIT",
   "dependencies": {
-    "@lvce-editor/server": "0.94.6"
+    "@lvce-editor/server": "0.94.7"
   }
 }


### PR DESCRIPTION
## Summary

- consume @lvce-editor/server 0.94.7 with native Windows parent-directory handling
- document the Windows persistence failure found during exploratory testing
- keep the cross-platform verification status in the consolidated issue report

## Verification

- npm ci
- npm run build:static
- npm test (298 passed, 16 skipped)
- npm run type-check
- npm run lint (0 errors, 16 pre-existing warnings)
- npm run e2e:headless --workspace=packages/e2e (64 passed, 6 skipped)
- npm run measure