### PR TITLE
fix: display extension command names

### DIFF
--- a/packages/keybindings-view/src/parts/GetCommandName/GetCommandName.ts
+++ b/packages/keybindings-view/src/parts/GetCommandName/GetCommandName.ts
@@ -1,0 +1,14 @@
+const extensionHostExecuteCommand = 'ExtensionHost.executeCommand'
+
+interface KeyBinding {
+  readonly args?: readonly unknown[]
+  readonly command: string
+}
+
+export const getCommandName = (keyBinding: KeyBinding): string => {
+  const { args, command } = keyBinding
+  if (command === extensionHostExecuteCommand && Array.isArray(args) && typeof args[0] === 'string') {
+    return args[0]
+  }
+  return command
+}

--- a/packages/keybindings-view/src/parts/ParseKeyBinding/ParseKeyBinding.ts
+++ b/packages/keybindings-view/src/parts/ParseKeyBinding/ParseKeyBinding.ts
@@ -1,9 +1,11 @@
 import type { ParsedKeyBinding } from '../ParsedKeyBinding/ParsedKeyBinding.ts'
+import * as GetCommandName from '../GetCommandName/GetCommandName.ts'
 import * as ParseKey from '../ParseKey/ParseKey.ts'
 
 export const parseKeyBinding = (keyBinding: any): ParsedKeyBinding => {
   return {
     ...keyBinding,
+    command: GetCommandName.getCommandName(keyBinding),
     rawKey: keyBinding.key,
     source: keyBinding.source || 'System',
     ...ParseKey.parseKey(keyBinding.key),

--- a/packages/keybindings-view/test/ParseKeyBindings.test.ts
+++ b/packages/keybindings-view/test/ParseKeyBindings.test.ts
@@ -23,3 +23,46 @@ test('parseKeyBindings', () => {
     },
   ])
 })
+
+test('parseKeyBindings - extension command', () => {
+  const keyBindings = [
+    {
+      args: ['eslint.executeAutofix'],
+      command: 'ExtensionHost.executeCommand',
+      key: KeyCode.Enter,
+    },
+  ]
+  expect(ParseKeyBindings.parseKeyBindings(keyBindings)).toEqual([
+    {
+      args: ['eslint.executeAutofix'],
+      command: 'eslint.executeAutofix',
+      isAlt: false,
+      isCtrl: false,
+      isShift: false,
+      key: 'Enter',
+      rawKey: 3,
+      source: 'System',
+    },
+  ])
+})
+
+test('parseKeyBindings - extension command without command argument', () => {
+  const keyBindings = [
+    {
+      command: 'ExtensionHost.executeCommand',
+      key: KeyCode.Enter,
+    },
+  ]
+  expect(ParseKeyBindings.parseKeyBindings(keyBindings)[0].command).toBe('ExtensionHost.executeCommand')
+})
+
+test('parseKeyBindings - extension command with invalid command argument', () => {
+  const keyBindings = [
+    {
+      args: [1],
+      command: 'ExtensionHost.executeCommand',
+      key: KeyCode.Enter,
+    },
+  ]
+  expect(ParseKeyBindings.parseKeyBindings(keyBindings)[0].command).toBe('ExtensionHost.executeCommand')
+})


### PR DESCRIPTION
Display the contributed extension command ID instead of the shared ExtensionHost.executeCommand wrapper in the Keyboard Shortcuts view.