### PR TITLE
Update ESLint dependencies

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,9 +12,9 @@
         "packages/*"
       ],
       "devDependencies": {
-        "@lvce-editor/eslint-config": "^18.0.0",
+        "@lvce-editor/eslint-config": "^18.2.0",
         "@types/node": "^24.13.3",
-        "eslint": "^10.8.0",
+        "eslint": "^10.8.1",
         "prettier": "^3.9.4",
         "typescript": "^6.0.3"
       }
@@ -2889,9 +2889,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-config": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-18.0.0.tgz",
-      "integrity": "sha512-Q1GuQAuyRga4uuvLeucGZkV68QnDfFzNbqJ4F2q83iN1wWphnSsCn0Snwg7Ky+FmZ89bIh218cVdia63kMZhvQ==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-config/-/eslint-config-18.2.0.tgz",
+      "integrity": "sha512-depjU3Z65NieU9IHl3xNUZIrP1Xt1AwQf6n9CEQxefGFttsx6XoW/CQ2BaBRD5ROTsYiSVXM9kaJF4g24TuX2Q==",
       "dev": true,
       "license": "MIT",
       "workspaces": [
@@ -2903,16 +2903,16 @@
         "@eslint/js": "10.0.1",
         "@eslint/json": "2.0.1",
         "@eslint/markdown": "8.0.3",
-        "@lvce-editor/eslint-plugin-devcontainer": "18.0.0",
-        "@lvce-editor/eslint-plugin-e2e": "18.0.0",
-        "@lvce-editor/eslint-plugin-eslint-config": "18.0.0",
-        "@lvce-editor/eslint-plugin-extension-json": "18.0.0",
-        "@lvce-editor/eslint-plugin-github-actions": "18.0.0",
-        "@lvce-editor/eslint-plugin-nvmrc": "18.0.0",
-        "@lvce-editor/eslint-plugin-regex": "18.0.0",
-        "@lvce-editor/eslint-plugin-rpc": "18.0.0",
-        "@lvce-editor/eslint-plugin-tsconfig": "18.0.0",
-        "@lvce-editor/eslint-plugin-virtual-dom": "18.0.0",
+        "@lvce-editor/eslint-plugin-devcontainer": "18.2.0",
+        "@lvce-editor/eslint-plugin-e2e": "18.2.0",
+        "@lvce-editor/eslint-plugin-eslint-config": "18.2.0",
+        "@lvce-editor/eslint-plugin-extension-json": "18.2.0",
+        "@lvce-editor/eslint-plugin-github-actions": "18.2.0",
+        "@lvce-editor/eslint-plugin-nvmrc": "18.2.0",
+        "@lvce-editor/eslint-plugin-regex": "18.2.0",
+        "@lvce-editor/eslint-plugin-rpc": "18.2.0",
+        "@lvce-editor/eslint-plugin-tsconfig": "18.2.0",
+        "@lvce-editor/eslint-plugin-virtual-dom": "18.2.0",
         "eslint-plugin-jest": "29.15.4",
         "eslint-plugin-n": "18.2.1",
         "eslint-plugin-package-json": "1.5.0",
@@ -2927,9 +2927,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-devcontainer": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-18.0.0.tgz",
-      "integrity": "sha512-NjgwH2NKwU3MFfsaMkf/eeOKlYdQMqhgyJiRvslhPcZL8lyzgVP5P88AE7pEXr/ZnamzEQOEtrtzH28Z1KBPjA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-devcontainer/-/eslint-plugin-devcontainer-18.2.0.tgz",
+      "integrity": "sha512-oGP5M6eRRNsxBNdeEWJHdB2lUU7MBlUKkSO9laZhdw8sz52cCTldh75IN3+Xj/WUN7tkHgN+RybfxjhfLzOg9g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2937,23 +2937,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-e2e": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-18.0.0.tgz",
-      "integrity": "sha512-W5SvLvHQVWR5aV+QJPTT/QRPbBHEoFyYY8zbAeaxwP3TpHmhdrJTHY0Ser8ZAKC8VzxhvpWOaVokgJWGMH6dmA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-e2e/-/eslint-plugin-e2e-18.2.0.tgz",
+      "integrity": "sha512-AIpv+tOAMqH+rBK/Mx7P7pzKpF3YnS3xCZJBoHxx4VdWBSMrhTNQJvkXdhIZIgu9uGKU6FbBTq+o9FBk1jTfhw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-eslint-config": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-eslint-config/-/eslint-plugin-eslint-config-18.0.0.tgz",
-      "integrity": "sha512-zZUDZdU8svl+cZ391YprAKNYULR/4nvtnJsDbi2RWEwhvixyXZLWEmakguFpav1g0xD+KfR95O+qddwtik3yow==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-eslint-config/-/eslint-plugin-eslint-config-18.2.0.tgz",
+      "integrity": "sha512-yVwr5EunNy7lh4sCaeu6y0/jYpMTqgP/S7lZOMz4OUn26skMxF+weRFjIKiADvx2FC65YkrWDx7eC0fRtk3AEA==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-extension-json": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-18.0.0.tgz",
-      "integrity": "sha512-FWK97+EyJdgaocSo5eRbMLobOO0IsEYD7krxZdpP+VUHzkXKRg50dnDOThWdAVTBba4fq/ld3kURgsymuIfQDg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-extension-json/-/eslint-plugin-extension-json-18.2.0.tgz",
+      "integrity": "sha512-Z6A3jwLDvUsDaP2AMZ80QCr7xGVCsJY5MPj4K5hMR6BeXm2nBqv4bp+NFFFFh9fcvzhh3Lf1Uq+r/uwAsL8p5A==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2961,9 +2961,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-github-actions": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-18.0.0.tgz",
-      "integrity": "sha512-5lorIivbeHoc/iAYfCY6Y3XFJ0jNc7zsqxQroAInQUlhTIeK8BNCjnkQIv4J1UiUkR0peGjddqmKmLYiVTPuKw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-github-actions/-/eslint-plugin-github-actions-18.2.0.tgz",
+      "integrity": "sha512-jzC9qzB6wl7lQREaiW1EWWIp8G+eOF6M71R3Xj6qGAbGhAbDvb/MOEHQsLZW/DBUTtDyskC7LU9UvxmxPE2H1g==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2972,9 +2972,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-nvmrc": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-18.0.0.tgz",
-      "integrity": "sha512-ATg67BM6gcOt8f2AvabsKKh8NzZezN+lM19ZAoZUuVGClciVqDVibAjbvmlLnTy4vxWq8uyTDcTvAuS/A0PKOg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-nvmrc/-/eslint-plugin-nvmrc-18.2.0.tgz",
+      "integrity": "sha512-fybjUNLG3Jk+4dHn9Jyj94EzFMN8f1HP0avE2o8IIGFbR5B3lBw49Hz9aRQEZMy8l4vbk3OtKC9h3q6t1sQ38w==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -2982,23 +2982,23 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-regex": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-18.0.0.tgz",
-      "integrity": "sha512-cuzNaGpak6XNsZSmJCLldougHiyjwGSZEEqxx3iCxrfW1/b1RCpaIuUBQGIdmBEF09Ql8QN3uHcnvaG1pl1LAw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-regex/-/eslint-plugin-regex-18.2.0.tgz",
+      "integrity": "sha512-Cm++lkCreG53R73iocNfXLOa/uVLjKRDugQBWV4sy2XVgyZvsZWeCKZWBfMsN+LP3MRVj2p0Fzlbi5ywHI47YQ==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-rpc": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-18.0.0.tgz",
-      "integrity": "sha512-c5SmTTzfKxL00a+CC5/Bz1pi1DZwXGVj2hOZszs70jVxKissYGaJXtlcuqC1LJXqzrUBJmcqe/cmlFlKIJhphg==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-rpc/-/eslint-plugin-rpc-18.2.0.tgz",
+      "integrity": "sha512-mPhh+IAk7NnlcuSfFLDclypKlY0PwBjJNc3hPn2Wma24Ww3kHwlU+p1SlvU/jU5T12kBcqb60djIseBL03xBnw==",
       "dev": true,
       "license": "MIT"
     },
     "node_modules/@lvce-editor/eslint-plugin-tsconfig": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-18.0.0.tgz",
-      "integrity": "sha512-OibcGVrGkpgXkJBSs1Aix+rm6TlCBZuR3C4A0DdxJlABdPpKLeLYGpGaR8bIwBunnivmKjJPaYPA0KCRW8S+tw==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-tsconfig/-/eslint-plugin-tsconfig-18.2.0.tgz",
+      "integrity": "sha512-nj9Rsrdbpdzqd4WrvGYWFCKOSALn/iqPrSHeyyQqpUf2+ZzsZxmy2pnnbCGuNozZ3BRr8AazwliygPcYflJIcw==",
       "dev": true,
       "license": "MIT",
       "dependencies": {
@@ -3006,9 +3006,9 @@
       }
     },
     "node_modules/@lvce-editor/eslint-plugin-virtual-dom": {
-      "version": "18.0.0",
-      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-18.0.0.tgz",
-      "integrity": "sha512-ueMuPSpbG1iAU4CF1SB/vwX1RSkSgx9nue/89tzGmn9UzAwJfLU4neSc5b+zo9vTVnNQ+4Jp38VFbhoz1BgFsA==",
+      "version": "18.2.0",
+      "resolved": "https://registry.npmjs.org/@lvce-editor/eslint-plugin-virtual-dom/-/eslint-plugin-virtual-dom-18.2.0.tgz",
+      "integrity": "sha512-bFPELVF4H7uSUDS7gQ4v2naq8gfJ+aTA0upxCkVxPkbrl2j+7sZP6aTtL6Tl+i90VnEZ57sJeJUu0DXjETDt5Q==",
       "dev": true,
       "license": "MIT"
     },
@@ -7024,9 +7024,9 @@
       }
     },
     "node_modules/eslint": {
-      "version": "10.8.0",
-      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.0.tgz",
-      "integrity": "sha512-nuKKvN+oIBO0koN7Tm7dlkmnkc21mtt0QJLwAKzjLq14y6lRTdVG36MZHJ8eQHwdJMwZbQNMlPOYedMq/oVJvQ==",
+      "version": "10.8.1",
+      "resolved": "https://registry.npmjs.org/eslint/-/eslint-10.8.1.tgz",
+      "integrity": "sha512-wqA7W2jbsC/BnV9Iv1UZpKVFkO1AdNoSmYW8NWG4HNOBbkAMvIqDZ27pI2f07dqn583NcIC44ckjAcOXDL1QbQ==",
       "dev": true,
       "license": "MIT",
       "workspaces": [

--- a/package.json
+++ b/package.json
@@ -25,9 +25,9 @@
     "printWidth": 150
   },
   "devDependencies": {
-    "@lvce-editor/eslint-config": "^18.0.0",
+    "@lvce-editor/eslint-config": "^18.2.0",
     "@types/node": "^24.13.3",
-    "eslint": "^10.8.0",
+    "eslint": "^10.8.1",
     "prettier": "^3.9.4",
     "typescript": "^6.0.3"
   }

--- a/packages/keybindings-view/test/ContextMenu.test.ts
+++ b/packages/keybindings-view/test/ContextMenu.test.ts
@@ -1,15 +1,15 @@
 import { expect, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import * as ContextMenu from '../src/parts/ContextMenu/ContextMenu.ts'
+import * as MenuEntryId from '../src/parts/MenuEntryId/MenuEntryId.ts'
 
-test.skip('show - invokes context menu with correct items', async () => {
+test('show2 - invokes context menu with correct items', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
-    'ContextMenu.show'() {},
+    'ContextMenu.show2'() {},
   })
+  const uid = 1
   const x = 100
   const y = 200
-  const id = 1
-  // @ts-ignore
-  await ContextMenu.show(x, y, id)
-  expect(mockRpc.invocations).toEqual([['ContextMenu.show', x, y, id]])
+  await ContextMenu.show2(uid, MenuEntryId.KeyBindingsTable, x, y, { menuId: MenuEntryId.KeyBindingsTable })
+  expect(mockRpc.invocations).toEqual([['ContextMenu.show2', uid, MenuEntryId.KeyBindingsTable, x, y, { menuId: MenuEntryId.KeyBindingsTable }]])
 })

--- a/packages/keybindings-view/test/GetKeyBindingsTableCellCommandVirtualDom.test.ts
+++ b/packages/keybindings-view/test/GetKeyBindingsTableCellCommandVirtualDom.test.ts
@@ -4,12 +4,22 @@ import * as ClassNames from '../src/parts/ClassNames/ClassNames.ts'
 import * as GetKeyBindingsTableCellCommandVirtualDom from '../src/parts/GetKeyBindingsTableCellCommandVirtualDom/GetKeyBindingsTableCellCommandVirtualDom.ts'
 import * as VirtualDomElements from '../src/parts/VirtualDomElements/VirtualDomElements.ts'
 
-test('getKeyBindingsTableCellCommandDom - with command and title', () => {
-  const keyBinding: VisibleKeyBinding = {
-    command: 'workbench.action.toggleSidebarVisibility',
-    commandMatches: [],
-    title: 'Toggle Sidebar Visibility',
-  }
+const createKeyBinding = (commandMatches: readonly number[]): VisibleKeyBinding => ({
+  command: 'workbench.action.toggleSidebarVisibility',
+  commandMatches,
+  isCtrl: false,
+  isEditingWhenExpression: false,
+  isEven: false,
+  isShift: false,
+  key: '',
+  keyMatches: [],
+  rowIndex: 0,
+  selected: false,
+  when: '',
+})
+
+test('getKeyBindingsTableCellCommandDom - without matches', () => {
+  const keyBinding = createKeyBinding([])
   expect(GetKeyBindingsTableCellCommandVirtualDom.getKeyBindingsTableCellCommandDom(keyBinding)).toEqual([
     {
       childCount: 1,
@@ -24,12 +34,8 @@ test('getKeyBindingsTableCellCommandDom - with command and title', () => {
   ])
 })
 
-test('getKeyBindingsTableCellCommandDom - with command only', () => {
-  const keyBinding: VisibleKeyBinding = {
-    command: 'workbench.action.toggleSidebarVisibility',
-    commandMatches: [],
-    title: '',
-  }
+test('getKeyBindingsTableCellCommandDom - with empty matches', () => {
+  const keyBinding = createKeyBinding([])
   expect(GetKeyBindingsTableCellCommandVirtualDom.getKeyBindingsTableCellCommandDom(keyBinding)).toEqual([
     {
       childCount: 1,
@@ -45,11 +51,7 @@ test('getKeyBindingsTableCellCommandDom - with command only', () => {
 })
 
 test('getKeyBindingsTableCellCommandDom - with highlights', () => {
-  const keyBinding: VisibleKeyBinding = {
-    command: 'workbench.action.toggleSidebarVisibility',
-    commandMatches: [0, 1, 3],
-    title: 'Toggle Sidebar Visibility',
-  }
+  const keyBinding = createKeyBinding([0, 1, 3])
   expect(GetKeyBindingsTableCellCommandVirtualDom.getKeyBindingsTableCellCommandDom(keyBinding)).toEqual([
     {
       childCount: 3,

--- a/packages/keybindings-view/test/GetKeyBindingsTableCellCommandVirtualDom.test.ts
+++ b/packages/keybindings-view/test/GetKeyBindingsTableCellCommandVirtualDom.test.ts
@@ -8,8 +8,6 @@ test('getKeyBindingsTableCellCommandDom - with command and title', () => {
   const keyBinding: VisibleKeyBinding = {
     command: 'workbench.action.toggleSidebarVisibility',
     commandMatches: [],
-    // @ts-ignore
-    highlights: [],
     title: 'Toggle Sidebar Visibility',
   }
   expect(GetKeyBindingsTableCellCommandVirtualDom.getKeyBindingsTableCellCommandDom(keyBinding)).toEqual([
@@ -26,12 +24,10 @@ test('getKeyBindingsTableCellCommandDom - with command and title', () => {
   ])
 })
 
-test.skip('getKeyBindingsTableCellCommandDom - with command only', () => {
+test('getKeyBindingsTableCellCommandDom - with command only', () => {
   const keyBinding: VisibleKeyBinding = {
     command: 'workbench.action.toggleSidebarVisibility',
     commandMatches: [],
-    // @ts-ignore
-    highlights: [],
     title: '',
   }
   expect(GetKeyBindingsTableCellCommandVirtualDom.getKeyBindingsTableCellCommandDom(keyBinding)).toEqual([
@@ -48,12 +44,10 @@ test.skip('getKeyBindingsTableCellCommandDom - with command only', () => {
   ])
 })
 
-test.skip('getKeyBindingsTableCellCommandDom - with highlights', () => {
+test('getKeyBindingsTableCellCommandDom - with highlights', () => {
   const keyBinding: VisibleKeyBinding = {
     command: 'workbench.action.toggleSidebarVisibility',
-    commandMatches: [],
-    // @ts-ignore
-    highlights: [1, 3],
+    commandMatches: [0, 1, 3],
     title: 'Toggle Sidebar Visibility',
   }
   expect(GetKeyBindingsTableCellCommandVirtualDom.getKeyBindingsTableCellCommandDom(keyBinding)).toEqual([
@@ -74,13 +68,12 @@ test.skip('getKeyBindingsTableCellCommandDom - with highlights', () => {
     },
     {
       childCount: 0,
-      text: 'orkbench.action.toggleSidebarVisibility',
+      text: 'or',
       type: VirtualDomElements.Text,
     },
     {
       childCount: 0,
-      // @ts-ignore
-      text: ` - ${keyBinding.title}`,
+      text: 'kbench.action.toggleSidebarVisibility',
       type: VirtualDomElements.Text,
     },
   ])

--- a/packages/keybindings-view/test/HandleClick.test.ts
+++ b/packages/keybindings-view/test/HandleClick.test.ts
@@ -2,11 +2,10 @@ import { expect, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { KeyBindingsState } from '../src/parts/KeyBindingsState/KeyBindingsState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
-import * as FocusKey from '../src/parts/FocusKey/FocusKey.ts'
 import * as HandleClick from '../src/parts/HandleClick/HandleClick.ts'
 import * as WhenExpression from '../src/parts/WhenExpression/WhenExpression.ts'
 
-test.skip('handleClick - edit icon path triggers openWidget', async () => {
+test('handleClick - edit icon path triggers openWidget', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
     'Focus.setFocus'() {},
     'KeyBindingsInitial.getKeyBindings'() {
@@ -24,16 +23,11 @@ test.skip('handleClick - edit icon path triggers openWidget', async () => {
   const eventY = 0
   const newState = await HandleClick.handleClick(state, eventX, eventY)
   expect(mockRpc.invocations).toEqual([['Viewlet.openWidget', 'DefineKeyBinding', 1]])
-  expect(newState.focus).toBe(WhenExpression.FocusKeyBindingsTable)
+  expect(newState).toBe(state)
 })
 
-test.skip('handleClick - outside edit icon triggers focus set', async () => {
-  using mockRpc = RendererWorker.registerMockRpc({
-    'Focus.setFocus'() {},
-    'KeyBindingsInitial.getKeyBindings'() {
-      return []
-    },
-  })
+test('handleClick - outside edit icon triggers focus set', async () => {
+  using mockRpc = RendererWorker.registerMockRpc({})
   const state = {
     ...createDefaultState(),
     editIconSize: 20,
@@ -44,6 +38,6 @@ test.skip('handleClick - outside edit icon triggers focus set', async () => {
   const eventX = 100 // Outside edit icon
   const eventY = 0
   const newState = await HandleClick.handleClick(state, eventX, eventY)
-  expect(mockRpc.invocations).toEqual([['Focus.setFocus', WhenExpression.FocusKeyBindingsTable]])
-  expect(newState.focus).toBe(FocusKey.Table)
+  expect(mockRpc.invocations).toEqual([])
+  expect(newState.focus).toBe(WhenExpression.FocusKeyBindingsTable)
 })

--- a/packages/keybindings-view/test/HandleContextMenu.test.ts
+++ b/packages/keybindings-view/test/HandleContextMenu.test.ts
@@ -1,12 +1,17 @@
 import { expect, test } from '@jest/globals'
 import { RendererWorker } from '@lvce-editor/rpc-registry'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as HandleContextMenu from '../src/parts/HandleContextMenu/HandleContextMenu.ts'
+import * as MenuEntryId from '../src/parts/MenuEntryId/MenuEntryId.ts'
 
-test.skip('handleContextMenu - shows context menu', async () => {
+test('handleContextMenu - shows context menu', async () => {
   using mockRpc = RendererWorker.registerMockRpc({
-    'ContextMenu.show'() {},
+    'ContextMenu.show2'() {},
   })
-  const result = await HandleContextMenu.handleContextMenu({} as any, 0, 10, 20)
-  expect(mockRpc.invocations).toEqual([['ContextMenu.show', 10, 20, 26]])
-  expect(result).toBeDefined()
+  const state = createDefaultState()
+  const result = await HandleContextMenu.handleContextMenu(state, 0, 10, 100)
+  expect(mockRpc.invocations).toEqual([
+    ['ContextMenu.show2', state.uid, MenuEntryId.KeyBindingsTable, 10, 100, { menuId: MenuEntryId.KeyBindingsTable }],
+  ])
+  expect(result).toBe(state)
 })

--- a/packages/keybindings-view/test/HandleEscape.test.ts
+++ b/packages/keybindings-view/test/HandleEscape.test.ts
@@ -1,12 +1,17 @@
 import { expect, test } from '@jest/globals'
+import { WhenExpression } from '@lvce-editor/constants'
 import type { KeyBindingsState } from '../src/parts/KeyBindingsState/KeyBindingsState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as HandleEscape from '../src/parts/HandleEscape/HandleEscape.ts'
 
-test.skip('handleEscape - when not recording returns same state', () => {
+test('handleEscape - when not recording focuses the table', () => {
   const state: KeyBindingsState = createDefaultState()
   const result = HandleEscape.handleEscape(state)
-  expect(result).toBe(state)
+  expect(result).toEqual({
+    ...state,
+    focus: WhenExpression.FocusKeyBindingsTable,
+    focusedIndex: -1,
+  })
 })
 
 test('handleEscape - when recording stops recording', () => {

--- a/packages/keybindings-view/test/HandleSearchActionClick.test.ts
+++ b/packages/keybindings-view/test/HandleSearchActionClick.test.ts
@@ -14,7 +14,7 @@ test('handleSearchActionClick - ClearSearchInput', async () => {
   expect(newState.value).toBe('')
 })
 
-test.skip('handleSearchActionClick - RecordKeys', async () => {
+test('handleSearchActionClick - RecordKeys', async () => {
   const state: KeyBindingsState = { ...createDefaultState(), isRecordingKeys: false }
   const newState: KeyBindingsState = await HandleSearchActionClick.handleSearchActionClick(state, InputName.RecordKeys)
   expect(newState.isRecordingKeys).toBe(true)

--- a/packages/keybindings-view/test/LoadContent.test.ts
+++ b/packages/keybindings-view/test/LoadContent.test.ts
@@ -5,7 +5,7 @@ import type { KeyBindingsState } from '../src/parts/KeyBindingsState/KeyBindings
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as LoadContent from '../src/parts/LoadContent/LoadContent.ts'
 
-test.skip('loadContent - computes derived fields and restores saved state', async () => {
+test('loadContent - computes derived fields and restores saved state', async () => {
   RendererWorker.registerMockRpc({
     'KeyBindingsInitial.getKeyBindings'() {
       return [

--- a/packages/keybindings-view/test/Resize.test.ts
+++ b/packages/keybindings-view/test/Resize.test.ts
@@ -1,7 +1,15 @@
 import { expect, test } from '@jest/globals'
 import type { Dimensions } from '../src/parts/Dimensions/Dimensions.ts'
+import type { KeyBindingsState } from '../src/parts/KeyBindingsState/KeyBindingsState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as Resize from '../src/parts/Resize/Resize.ts'
+
+const getDimensions = (state: KeyBindingsState): Dimensions => ({
+  height: state.height,
+  width: state.width,
+  x: state.x,
+  y: state.y,
+})
 
 test('resize - basic dimensions', () => {
   const state = {
@@ -16,7 +24,7 @@ test('resize - basic dimensions', () => {
     y: 0,
   }
   const newState = Resize.resize(state, dimensions)
-  expect(newState).toMatchObject(dimensions)
+  expect(getDimensions(newState)).toEqual(dimensions)
   expect(newState.columnWidth1).toBeCloseTo(193.33333333333334)
   expect(newState.columnWidth2).toBeCloseTo(193.33333333333334)
   expect(newState.columnWidth3).toBeCloseTo(163.33333333333334)
@@ -35,7 +43,7 @@ test('resize - zero width', () => {
     y: 0,
   }
   const newState = Resize.resize(state, dimensions)
-  expect(newState).toMatchObject(dimensions)
+  expect(getDimensions(newState)).toEqual(dimensions)
   expect(newState.columnWidth1).toBeCloseTo(-3.3333333333333335)
   expect(newState.columnWidth2).toBeCloseTo(-3.3333333333333335)
   expect(newState.columnWidth3).toBeCloseTo(-33.333333333333336)
@@ -54,7 +62,7 @@ test('resize - small width', () => {
     y: 0,
   }
   const newState = Resize.resize(state, dimensions)
-  expect(newState).toMatchObject(dimensions)
+  expect(getDimensions(newState)).toEqual(dimensions)
   expect(newState.columnWidth1).toBe(20)
   expect(newState.columnWidth2).toBe(20)
   expect(newState.columnWidth3).toBe(-10)
@@ -73,7 +81,7 @@ test('resize - large width', () => {
     y: 0,
   }
   const newState = Resize.resize(state, dimensions)
-  expect(newState).toMatchObject(dimensions)
+  expect(getDimensions(newState)).toEqual(dimensions)
   expect(newState.columnWidth1).toBeCloseTo(383.3333333333333)
   expect(newState.columnWidth2).toBeCloseTo(383.3333333333333)
   expect(newState.columnWidth3).toBeCloseTo(353.3333333333333)

--- a/packages/keybindings-view/test/Resize.test.ts
+++ b/packages/keybindings-view/test/Resize.test.ts
@@ -1,12 +1,14 @@
 import { expect, test } from '@jest/globals'
 import type { Dimensions } from '../src/parts/Dimensions/Dimensions.ts'
+import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as Resize from '../src/parts/Resize/Resize.ts'
 
-test.skip('resize - basic dimensions', () => {
+test('resize - basic dimensions', () => {
   const state = {
+    ...createDefaultState(),
     contentPadding: 20,
     width: 300,
-  } as any
+  }
   const dimensions: Dimensions = {
     height: 400,
     width: 600,
@@ -14,20 +16,18 @@ test.skip('resize - basic dimensions', () => {
     y: 0,
   }
   const newState = Resize.resize(state, dimensions)
-  expect(newState).toEqual({
-    ...state,
-    ...dimensions,
-    columnWidth1: 193.33333333333334,
-    columnWidth2: 193.33333333333334,
-    columnWidth3: 193.33333333333334,
-  })
+  expect(newState).toMatchObject(dimensions)
+  expect(newState.columnWidth1).toBeCloseTo(193.33333333333334)
+  expect(newState.columnWidth2).toBeCloseTo(193.33333333333334)
+  expect(newState.columnWidth3).toBeCloseTo(163.33333333333334)
 })
 
-test.skip('resize - zero width', () => {
+test('resize - zero width', () => {
   const state = {
+    ...createDefaultState(),
     contentPadding: 10,
     width: 100,
-  } as any
+  }
   const dimensions: Dimensions = {
     height: 200,
     width: 0,
@@ -35,20 +35,18 @@ test.skip('resize - zero width', () => {
     y: 0,
   }
   const newState = Resize.resize(state, dimensions)
-  expect(newState).toEqual({
-    ...state,
-    ...dimensions,
-    columnWidth1: -3.3333333333333335,
-    columnWidth2: -3.3333333333333335,
-    columnWidth3: -3.3333333333333335,
-  })
+  expect(newState).toMatchObject(dimensions)
+  expect(newState.columnWidth1).toBeCloseTo(-3.3333333333333335)
+  expect(newState.columnWidth2).toBeCloseTo(-3.3333333333333335)
+  expect(newState.columnWidth3).toBeCloseTo(-33.333333333333336)
 })
 
-test.skip('resize - small width', () => {
+test('resize - small width', () => {
   const state = {
+    ...createDefaultState(),
     contentPadding: 30,
     width: 200,
-  } as any
+  }
   const dimensions: Dimensions = {
     height: 300,
     width: 90,
@@ -56,20 +54,18 @@ test.skip('resize - small width', () => {
     y: 0,
   }
   const newState = Resize.resize(state, dimensions)
-  expect(newState).toEqual({
-    ...state,
-    ...dimensions,
-    columnWidth1: 20,
-    columnWidth2: 20,
-    columnWidth3: 20,
-  })
+  expect(newState).toMatchObject(dimensions)
+  expect(newState.columnWidth1).toBe(20)
+  expect(newState.columnWidth2).toBe(20)
+  expect(newState.columnWidth3).toBe(-10)
 })
 
-test.skip('resize - large width', () => {
+test('resize - large width', () => {
   const state = {
+    ...createDefaultState(),
     contentPadding: 50,
     width: 500,
-  } as any
+  }
   const dimensions: Dimensions = {
     height: 800,
     width: 1200,
@@ -77,11 +73,8 @@ test.skip('resize - large width', () => {
     y: 0,
   }
   const newState = Resize.resize(state, dimensions)
-  expect(newState).toEqual({
-    ...state,
-    ...dimensions,
-    columnWidth1: 383.3333333333333,
-    columnWidth2: 383.3333333333333,
-    columnWidth3: 383.3333333333333,
-  })
+  expect(newState).toMatchObject(dimensions)
+  expect(newState.columnWidth1).toBeCloseTo(383.3333333333333)
+  expect(newState.columnWidth2).toBeCloseTo(383.3333333333333)
+  expect(newState.columnWidth3).toBeCloseTo(353.3333333333333)
 })

--- a/packages/keybindings-view/test/ShowSameKeyBindings.test.ts
+++ b/packages/keybindings-view/test/ShowSameKeyBindings.test.ts
@@ -1,5 +1,4 @@
 import { expect, test } from '@jest/globals'
-import { RendererWorker } from '@lvce-editor/rpc-registry'
 import type { KeyBindingsState } from '../src/parts/KeyBindingsState/KeyBindingsState.ts'
 import { createDefaultState } from '../src/parts/CreateDefaultState/CreateDefaultState.ts'
 import * as InputSource from '../src/parts/InputSource/InputSource.ts'
@@ -26,13 +25,11 @@ test('showSameKeyBindings - sets value to quoted key with spaces', async () => {
   expect(result.value).toContain(' + ')
 })
 
-test.skip('showSameKeyBindings - no focused item returns state', async () => {
-  RendererWorker.registerMockRpc({})
-
+test('showSameKeyBindings - selected index outside items returns state', async () => {
   const state: KeyBindingsState = {
     ...createDefaultState(),
-    focusedIndex: -1,
     items: [],
+    selectedIndex: 0,
   }
 
   const result: KeyBindingsState = await ShowSameKeyBindings.showSameKeyBindings(state)
@@ -40,11 +37,7 @@ test.skip('showSameKeyBindings - no focused item returns state', async () => {
   expect(result).toBe(state)
 })
 
-test.skip('showSameKeyBindings - sets value to focused keybinding and focuses input', async () => {
-  RendererWorker.registerMockRpc({
-    'Focus.setFocus'() {},
-  })
-
+test('showSameKeyBindings - sets value to focused keybinding and focuses input', async () => {
   const state: KeyBindingsState = {
     ...createDefaultState(),
     focusedIndex: 0,
@@ -58,11 +51,11 @@ test.skip('showSameKeyBindings - sets value to focused keybinding and focuses in
     ],
     maxVisibleItems: 10,
     parsedKeyBindings: [],
+    selectedIndex: 0,
   }
 
   const result: KeyBindingsState = await ShowSameKeyBindings.showSameKeyBindings(state)
 
   expect(result.value).toBe('"Ctrl + Space"')
   expect(result.inputSource).toBe(InputSource.Script)
-  // expect focus call is made
 })

--- a/packages/keybindings-view/test/ToggleRecordingKeys.test.ts
+++ b/packages/keybindings-view/test/ToggleRecordingKeys.test.ts
@@ -3,7 +3,7 @@ import * as Create from '../src/parts/Create/Create.ts'
 import * as KeyBindingsStates from '../src/parts/KeyBindingsStates/KeyBindingsStates.ts'
 import * as ToggleRecordingKeys from '../src/parts/ToggleRecordingKeys/ToggleRecordingKeys.ts'
 
-test.skip('toggles recording keys from false to true', async () => {
+test('toggles recording keys from false to true', async () => {
   // Create a valid initial state
   Create.create(1, '', 0, 0, 0, 0, 0)
   const { oldState } = KeyBindingsStates.get(1)


### PR DESCRIPTION
Updates ESLint and `@lvce-editor/eslint-config` to their latest versions.

The updated Jest lint rules exposed 16 disabled tests. This also re-enables those tests and updates their stale fixtures and expectations to the current keybindings APIs.

Validation:
- `npm run lint`
- `npm test --workspace=packages/keybindings-view` (105 suites, 317 tests)